### PR TITLE
logging location of the file being read #83

### DIFF
--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -69,6 +69,7 @@ public class PipeUtil {
 
 	private static Dataset<Row> read(DataFrameReader reader, Pipe p, boolean addSource) {
 		Dataset<Row> input = null;
+		LOG.warn("Reading " + p);
 		if (p.getProps().containsKey(FilePipe.LOCATION)) {
 			input = reader.load(p.get(FilePipe.LOCATION));
 		}


### PR DESCRIPTION
The output location would look like : (2nd line)
2021-12-29 18:18:22,739 [main] WARN  zingg.util.PipeUtil - Reading input PARQUET
**2021-12-29 18:18:22,740 [main] WARN  zingg.util.PipeUtil - Reading location: models/1000/trainingData//unmarked/**

If entire pipe info is printed, for some scenario other information also get printed. So this option dropped
e.g.
Reading input Pipe [name=null, format=PARQUET, preprocessors=null, props={location=models/1000/trainingData//unmarked/}, schema=null]
Reading input Pipe [name=customers, format=SNOWFLAKE, preprocessors=null, props={sfUrl=tsa87485.snowflakecomputing.com, sfUser=sonalgoyal, sfPassword=ZZZZZ, sfDatabase=DEMO_DB, sfSchema=PUBLIC, sfWarehouse=COMPUTE_WH, dbtable=CUSTOMERS}, schema=null]