### PR TITLE
Giving same cluster id to all records linked from multiple sources #108

### DIFF
--- a/core/src/main/java/zingg/Linker.java
+++ b/core/src/main/java/zingg/Linker.java
@@ -61,10 +61,9 @@ public class Linker extends Matcher {
 			if (args.getOutput() != null) {
 
 				// input dupes are pairs
-				dupesActual = DFUtil.addClusterRowNumber(dupesActual, spark);
-				dupesActual = Util.addUniqueCol(dupesActual, ColName.CLUSTER_COLUMN);
-				Dataset<Row> dupes1 = DSUtil.alignLinked(dupesActual, args);
-				Dataset<Row> dupes2 = dupes1.orderBy(ColName.CLUSTER_COLUMN);
+				//dupesActual = DFUtil.addClusterRowNumber(dupesActual, spark);
+				dupesActual = Util.addUniqueCol(dupesActual, ColName.ID_COL);
+				Dataset<Row> dupes2 = DSUtil.alignLinked(dupesActual, args);
 				LOG.debug("uncertain output schema is " + dupes2.schema());
 				PipeUtil.write(dupes2, args, ctx, args.getOutput());
 			}

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -92,6 +92,7 @@ public class DSUtil {
 
 	public static Dataset<Row> alignLinked(Dataset<Row> dupesActual, Arguments args) {
 		dupesActual = dupesActual.cache();
+		dupesActual = dupesActual.withColumnRenamed(ColName.ID_COL, ColName.CLUSTER_COLUMN);
 		List<Column> cols = new ArrayList<Column>();
 		cols.add(dupesActual.col(ColName.CLUSTER_COLUMN));
 		cols.add(dupesActual.col(ColName.SOURCE_COL));
@@ -102,6 +103,7 @@ public class DSUtil {
 		}		
 
 		Dataset<Row> dupes1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
+		dupes1 = dupes1.dropDuplicates(ColName.CLUSTER_COLUMN, ColName.SOURCE_COL);
 	 	List<Column> cols1 = new ArrayList<Column>();
 		cols1.add(dupesActual.col(ColName.CLUSTER_COLUMN));
 		cols1.add(dupesActual.col(ColName.COL_PREFIX +ColName.SOURCE_COL));


### PR DESCRIPTION
addUniqueCol() is also referred to TrainingDataFinder. 
dropDuplicate() could be expansive, but perhaps necessary. Applied on data from master source only.

Note: addUniqueCol() is also duplicated in FileUtil.java, nowhere used as of now.