### PR TITLE
zingg.sh path included in PATH env var in Dockerfile #111

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/bitnami/spark:3.1.2
 ENV SPARK_MASTER local[*]
 ENV ZINGG_HOME /zingg-0.3.1-SNAPSHOT
+ENV PATH $ZINGG_HOME/scripts:$PATH
 WORKDIR /
 USER root
 WORKDIR /zingg-0.3.1-SNAPSHOT


### PR DESCRIPTION
After the change the path becomes. User can directly access zingg.sh from any place.
/zingg-0.3.1-SNAPSHOT/scripts:/opt/bitnami/python/bin:/opt/bitnami/java/bin:/opt/bitnami/spark/bin:/opt/bitnami/spark/sbin:/opt/bitnami/common/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin