### PR TITLE
z_source column is added at the end of dataset in alignDupes 

### DIFF
--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -95,23 +95,23 @@ public class DSUtil {
 		dupesActual = dupesActual.withColumnRenamed(ColName.ID_COL, ColName.CLUSTER_COLUMN);
 		List<Column> cols = new ArrayList<Column>();
 		cols.add(dupesActual.col(ColName.CLUSTER_COLUMN));
-		cols.add(dupesActual.col(ColName.SOURCE_COL));
 		cols.add(dupesActual.col(ColName.SCORE_COL));
 		
 		for (FieldDefinition def: args.getFieldDefinition()) {
 			cols.add(dupesActual.col(def.fieldName));					
-		}		
+		}	
+		cols.add(dupesActual.col(ColName.SOURCE_COL));	
 
 		Dataset<Row> dupes1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
 		dupes1 = dupes1.dropDuplicates(ColName.CLUSTER_COLUMN, ColName.SOURCE_COL);
 	 	List<Column> cols1 = new ArrayList<Column>();
 		cols1.add(dupesActual.col(ColName.CLUSTER_COLUMN));
-		cols1.add(dupesActual.col(ColName.COL_PREFIX +ColName.SOURCE_COL));
 		cols1.add(dupesActual.col(ColName.SCORE_COL));
 		
 		for (FieldDefinition def: args.getFieldDefinition()) {
 			cols1.add(dupesActual.col(ColName.COL_PREFIX + def.fieldName));			
 		}		
+		cols1.add(dupesActual.col(ColName.COL_PREFIX +ColName.SOURCE_COL));
 		/*if (args.getJobId() != -1) {
 			cols1.add(dupesActual.col(ColName.SPARK_JOB_ID_COL));
 		}*/

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -131,11 +131,11 @@ public class DSUtil {
 		cols.add(dupesActual.col(ColName.ID_COL));
 		cols.add(dupesActual.col(ColName.PREDICTION_COL));
 		cols.add(dupesActual.col(ColName.SCORE_COL));
-		cols.add(dupesActual.col(ColName.SOURCE_COL));
 		
 		for (FieldDefinition def: args.getFieldDefinition()) {
 			cols.add(dupesActual.col(def.fieldName));						
 		}
+		cols.add(dupesActual.col(ColName.SOURCE_COL));
 		
 		Dataset<Row> dupes1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
 	 	List<Column> cols1 = new ArrayList<Column>();
@@ -145,10 +145,10 @@ public class DSUtil {
 		//cols1.add(dupesActual.col(ColName.PROBABILITY_COL));
 		cols1.add(dupesActual.col(ColName.SCORE_COL));
 
-		cols1.add(dupesActual.col(ColName.COL_PREFIX +ColName.SOURCE_COL));
 		for (FieldDefinition def: args.getFieldDefinition()) {
 			cols1.add(dupesActual.col(ColName.COL_PREFIX + def.fieldName));			
 		}
+		cols1.add(dupesActual.col(ColName.COL_PREFIX +ColName.SOURCE_COL));
 		/*if (args.getJobId() != -1) {
 			cols1.add(dupesActual.col(ColName.SPARK_JOB_ID_COL));
 		}*/


### PR DESCRIPTION
It is fine to have z_source in the beginning in alignLinked() for better user experience. It's an end output file.
This file is mandatory for the newly generated models to test.
Reference GH-95