### PR TITLE
Documentation broken links #118

### DIFF
--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -103,7 +103,7 @@ Application captures a few measurements for runtime metrics such as *no. of data
 
 <span style="color:maroon">**Zingg does not capture any user data or input data and will never do so.**</span>
 
-This feature may be disabled by setting this flag to false. Default value is true. For details, refer to [Zingg Analytics](../analytics.md)
+This feature may be disabled by setting this flag to false. Default value is true. For details, refer to [Security And Privacy](../security.md)
 
 ## Passing Configuration value through system environment variable
 If a user does not want to pass value of any JSON parameter through config file for security reasons or otherwise, they can configure that value through system environment variable. The system variable name needs to be put in the config file in place of its json value. At runtime, the config file gets updated with the value of the environment variable.

--- a/docs/stepByStep.md
+++ b/docs/stepByStep.md
@@ -23,13 +23,13 @@ Decide your hardware based on the [performance numbers](setup/hardwareSizing.md)
 Zingg needs a configuration file which defines the data and what kind of matching is needed. You can create the configuration file by following the instructions [here](setup/configuration.md)
 
 ### Step 4: Create the training data
-Zingg builds a new set of models(blocking and similarity) for every new schema definition(columns and match types). This means running the *findTrainingData* and *label* phases multiple times to build the training dataset form which Zingg will learn. You can read more [here](setup/createTrainingData.md)
+Zingg builds a new set of models(blocking and similarity) for every new schema definition(columns and match types). This means running the *findTrainingData* and *label* phases multiple times to build the training dataset form which Zingg will learn. You can read more [here](setup/training/createTrainingData.md)
 
 ### Step 5: Build and save the model
 The training data in Step 4 above is used to train Zingg and build and save the models. This is done by running the *train* phase. Read more [here](setup/train.md)
 
 ### Step 6: Voila, lets match!
-Its now time to apply the model above on our data. This si done by running the *match* or the *link* phases depending on whether you are matching within a single source or linking multiple sources respectively. You can read more about [matching](setup/match.md) and [linking](setup/linking.md)
+Its now time to apply the model above on our data. This si done by running the *match* or the *link* phases depending on whether you are matching within a single source or linking multiple sources respectively. You can read more about [matching](setup/match.md) and [linking](setup/match.md#link)
 
 As long as your input columns and the field types are not changing, the same model should work and you do not need to build a new model. If you change the match type, you can cotinue to use the training data and add more labelled pairs on top of it. 
 


### PR DESCRIPTION
Following links have been rectified. (#118)
* Create the Training Data
* linking    [match.md#link]
* Analytics -> security&privacy