### PR TITLE
Labeller - if it is not known that it is a match or not, similarity score should not be printed #114

### DIFF
--- a/client/src/main/java/zingg/client/Arguments.java
+++ b/client/src/main/java/zingg/client/Arguments.java
@@ -162,7 +162,6 @@ public class Arguments implements Serializable {
 					true);
 			LOG.warn("Config Argument is " + filePath);
 			Arguments args = mapper.readValue(new File(filePath), Arguments.class);
-			LOG.warn("collectMetrics is " + args.getCollectMetrics());
 			LOG.warn("phase is " + phase);
 			checkValid(args, phase);
 			return args;			

--- a/client/src/main/java/zingg/client/Client.java
+++ b/client/src/main/java/zingg/client/Client.java
@@ -38,6 +38,7 @@ public class Client implements Serializable {
 		this.options = options;
 		try {
 			buildAndSetArguments(args, options);
+			printAnalyticsBanner(arguments.getCollectMetrics());
 			setZingg(args, options);					
 		}
 		catch (Exception e) {
@@ -80,6 +81,10 @@ public class Client implements Serializable {
 		
 			String j = options.get(options.MODEL_ID).value;
 			args.setModelId(j);
+		}
+		if (options.get(options.COLLECT_METRICS)!= null) {
+			String j = options.get(options.COLLECT_METRICS).value;
+			args.setCollectMetrics(Boolean.valueOf(j));
 		}
 		setArguments(args);
 	}
@@ -143,7 +148,6 @@ public class Client implements Serializable {
 			else {
 				arguments = Arguments.createArgumentsFromJSONString(options.get(ClientOptions.CONF).value, phase);
 			}
-			printAnalyticsBanner(arguments.getCollectMetrics());
 
 			client = new Client(arguments, options);	
 			client.init();

--- a/client/src/main/java/zingg/client/ClientOptions.java
+++ b/client/src/main/java/zingg/client/ClientOptions.java
@@ -26,6 +26,7 @@ public class ClientOptions {
 	public static final String FORMAT = "--format";
 	public static final String ZINGG_DIR = "--zinggDir";
 	public static final String MODEL_ID = "--modelId";
+	public static final String COLLECT_METRICS = "--collectMetrics";
 	
 	 // Options that do not take arguments.
 	public static final String HELP = "--help";
@@ -53,6 +54,7 @@ public class ClientOptions {
 		optionMaster.put(FORMAT, new Option(FORMAT, true, "format of the data", false, false));
 		optionMaster.put(ZINGG_DIR, new Option(ZINGG_DIR, true, "location of Zingg models, defaults to /tmp/zingg", false, false));
 		optionMaster.put(MODEL_ID, new Option(MODEL_ID, true, "model identifier, can be a number ", false, false));
+		optionMaster.put(COLLECT_METRICS, new Option(COLLECT_METRICS, true, "collect analytics, true/false  ", false, false));
 				
 		//no args
 		optionMaster.put(HELP,new Option(HELP,  false, "print usage information", true, false));

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -101,9 +101,14 @@ public class Labeller extends ZinggBase {
 				prediction = currentPair.head().getAs(ColName.PREDICTION_COL);
 	
 				msg1 = String.format("\tCurrent labelling round  : %d/%d pairs labelled\n", index, totalPairs);
-				String matchType = LabelMatchType.get(prediction).msg;
-				msg2 = String.format("\tZingg predicts the above records %s with a similarity score of %.2f", 
-					matchType, score);
+				String matchType = LabelMatchType.get(prediction).msg;				
+				if (prediction == ColValues.IS_NOT_KNOWN_PREDICTION) {
+					msg2 = String.format(
+							"\tZingg does not do any prediction for the above pairs as Zingg is still collecting training data to build the preliminary models.");
+				} else {
+					msg2 = String.format("\tZingg predicts the above records %s with a similarity score of %.2f",
+							matchType, score);
+				}
 				//String msgHeader = msg1 + msg2;
 
 				selected_option = displayRecordsAndGetUserInput(DSUtil.select(currentPair, displayCols), msg1, msg2);


### PR DESCRIPTION
Improved message if prediction is not known.
It also has collectMetrics CLI option changes.
Unimportant messages have been removed for collectMetrics case.