### PR TITLE
handling null value of datatype Double #95

### DIFF
--- a/core/src/main/java/zingg/hash/Round.java
+++ b/core/src/main/java/zingg/hash/Round.java
@@ -13,7 +13,7 @@ public class Round extends HashFunction implements UDF1<Double, Long>{
 
 	 @Override
 	 public Long call(Double field) {
-		 return Math.round(field);
+		 return field == null ? null : Math.round(field);
 	 }
 
 	 @Override


### PR DESCRIPTION
Tested with Amazon-Google Structured data. All phases worked fine.
In the output match, the field is coming as ""
```
=======    Excerpts from /tmp/zinggOutput    =======
0.0,0.9999956199060517,11,4,production prem cs3 mac upgrad,adobe software,805.99
0.9987778680723014,0.9987778680723014,22,10,paper art : gift wrapping,arc-media-inc .,""
0.4456599013281326,0.9999956199060517,32,15,omnioutliner professional 3.0,csdc,69.95
0.0,0.47848460421892147,36,17,upg sgms 1000 incremental node,sonic-systems-inc .,"

```