### PR TITLE
prediction score: set precision to 2 with ~ floor mode

### DIFF
--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -107,7 +107,7 @@ public class Labeller extends ZinggBase {
 							"\tZingg does not do any prediction for the above pairs as Zingg is still collecting training data to build the preliminary models.");
 				} else {
 					msg2 = String.format("\tZingg predicts the above records %s with a similarity score of %.2f",
-							matchType, score);
+							matchType, Math.floor(score * 100) * 0.01);
 				}
 				//String msgHeader = msg1 + msg2;
 


### PR DESCRIPTION
It works like below.
e.g.
MATCH with a similarity score of {score:%f} {score:%.2f}  {newScore:%.2f}
MATCH with a similarity score of 0.965285 0.97 0.96
MATCH with a similarity score of 0.999966 1.00 0.99