### PR TITLE
In TrainMatcher class, ZinggOptions set to TRAIN_MATCH

### DIFF
--- a/core/src/main/java/zingg/TrainMatcher.java
+++ b/core/src/main/java/zingg/TrainMatcher.java
@@ -35,7 +35,7 @@ public class TrainMatcher extends Matcher{
 	private Trainer trainer;
 
     public TrainMatcher() {
-        setZinggOptions(ZinggOptions.MATCH);
+        setZinggOptions(ZinggOptions.TRAIN_MATCH);
 		trainer = new Trainer();
     }
 


### PR DESCRIPTION
ZinggOptions set to correct value i.e. "TRAIN_MATCH" for the class
This change gives correct google analytics data.