### PR TITLE
Initial changes for Spark to Snowpark migration

### DIFF
--- a/client/src/main/java/zingg/client/pipe/Pipe.java
+++ b/client/src/main/java/zingg/client/pipe/Pipe.java
@@ -5,11 +5,15 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.spark.sql.SaveMode;
+//import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonValue;
+
+import com.snowflake.snowpark.*;
+import com.snowflake.snowpark.types.*;
+import com.snowflake.snowpark.functions.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/core/src/main/java/zingg/ZinggBase.java
+++ b/core/src/main/java/zingg/ZinggBase.java
@@ -1,16 +1,22 @@
 package zingg;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.list.LazyList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.Left;
 import org.apache.spark.sql.types.DataType;
 
+import javassist.bytecode.stackmap.TypeTag;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
 import zingg.client.Arguments;
 import zingg.client.FieldDefinition;
 import zingg.client.IZingg;
@@ -25,6 +31,12 @@ import zingg.feature.Feature;
 import zingg.feature.FeatureFactory;
 import zingg.hash.HashFunction;
 
+import com.snowflake.snowpark.types.*;
+import com.snowflake.snowpark.functions.*;
+import com.snowflake.snowpark.*;
+import java.util.ArrayList;
+import java.util.List;
+
 import zingg.util.HashUtil;
 import zingg.util.PipeUtil;
 
@@ -34,6 +46,7 @@ public abstract class ZinggBase implements Serializable, IZingg {
 	
     protected JavaSparkContext ctx;
 	protected SparkSession spark;
+    protected Session snow;
     protected static String name;
     protected ZinggOptions zinggOptions;
     protected ListMap<DataType, HashFunction> hashFunctions;
@@ -48,17 +61,20 @@ public abstract class ZinggBase implements Serializable, IZingg {
         throws ZinggClientException {
         startTime = System.currentTimeMillis();
         this.args = args;
+        
         try{
-            spark = SparkSession
-                .builder()
-                .appName("Zingg"+args.getJobId())
-                .getOrCreate();
-            ctx = new JavaSparkContext(spark.sparkContext());
-            JavaSparkContext.jarOfClass(IZingg.class);
-            LOG.debug("Context " + ctx.toString());
-            initHashFns();
-            loadFeatures();
-            ctx.setCheckpointDir("/tmp/checkpoint");	
+            snow = snowparkSession();
+
+            // spark = SparkSession
+            //     .builder()
+            //     .appName("Zingg"+args.getJobId())
+            //     .getOrCreate();
+            // ctx = new JavaSparkContext(spark.sparkContext());
+            // JavaSparkContext.jarOfClass(IZingg.class);
+            // LOG.debug("Context " + ctx.toString());
+            // initHashFns();
+            // loadFeatures();
+            // ctx.setCheckpointDir("/tmp/checkpoint");	
         }
         catch(Throwable e) {
             if (LOG.isDebugEnabled()) e.printStackTrace();
@@ -66,6 +82,43 @@ public abstract class ZinggBase implements Serializable, IZingg {
         }
     }
 
+    Session snowparkSession() {
+        Map<String, String> map = new HashMap<String, String>(); 
+
+        map.put("URL", "https://nt28656.southeast-asia.azure.snowflakecomputing.com:443");
+        map.put( "USER" , "navinrathore");
+        map.put(  "PASSWORD" , "main5$NAN");
+        map.put(  "ROLE" , "ACCOUNTADMIN");
+        map.put(  "WAREHOUSE" , "COMPUTE_WH");
+        map.put(  "DB" , "SNOWFLAKE_SAMPLE_DATA");
+        map.put(  "SCHEMA" , "WEATHER");
+        
+        // // config file option is Session.builder.configFile("").create
+        // val session = Session.builder.configs(configs).create
+        // //val df = session.sql("desc table DAILY_16_TOTAL")
+        //  //val df = session.sql("select * from DAILY_16_TOTAL")
+        //  session.table("DAILY_16_TOTAL")
+        //df.show(2)
+        //ConsoleHandler cs = new ConsoleHandler();
+        //Session s = new Session();
+        System.out.println( "Hello World! from scala library" );
+        Session ses = Session.builder().configs(map).create();
+        //Session ses = Session.builder().configFile("xyz").create();
+        DataFrame df = ses.sql("SELECT  *  FROM (SELECT 'Hello World SF!' greeting) LIMIT 10");
+        //DataFrame df = ses.sql("desc table DAILY_16_TOTAL");
+        df.show();
+        List<String> a = new ArrayList<String> ();
+        a.add("Buenos Aires");
+        a.add("La Plata");
+        a.add("Córdoba");
+        scala.reflect.api.TypeTags.TypeTag<String> evidence = null;
+        Seq<String> seq = JavaConverters.asScalaIteratorConverter(a.iterator()).asScala().toSeq();
+        DataFrame df2 = ses.createDataFrame(seq, evidence).toDF("Greeting", null);
+
+        System.out.println( "Hello World! from java program" );
+        df2.show();
+       return ses;
+    }
 
     @Override
     public void cleanup() throws ZinggClientException {

--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -11,15 +11,16 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.DataFrameReader;
-import org.apache.spark.sql.DataFrameWriter;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SaveMode;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
-import org.apache.spark.storage.StorageLevel;
+//import org.apache.spark.api.java.String;
+//import org.apache.spark.sql.DataFrameReader;DataFrameReader
+import com.snowflake.snowpark.*;
+//import org.apache.spark.sql.DataFrameWriter;
+// import org.apache.spark.sql.Dataset;
+// import org.apache.spark.sql.Row;
+//import org.apache.spark.sql.SaveMode;
+//import org.apache.spark.sql.SparkSession;
+//import org.apache.spark.sql.functions;
+//import org.apache.spark.storage.StorageLevel;
 
 //import zingg.scala.DFUtil;
 import zingg.client.Arguments;
@@ -32,17 +33,20 @@ import zingg.client.pipe.Pipe;
 import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
+import com.snowflake.snowpark.*;
+import com.snowflake.snowpark.types.*;
+import com.snowflake.snowpark.functions.*;
 
 //import com.datastax.driver.core.ProtocolVersion;
 //import com.datastax.driver.core.ResultSet;
 //import com.datastax.driver.core.Session;
 //import com.datastax.spark.connector.DataFrameFunctions;
-import com.datastax.spark.connector.cql.CassandraConnector;
-import com.datastax.spark.connector.cql.ClusteringColumn;
-import com.datastax.spark.connector.cql.ColumnDef;
-import com.datastax.spark.connector.cql.TableDef;
-
-import com.datastax.spark.connector.cql.*;
+// import com.datastax.spark.connector.cql.CassandraConnector;
+// import com.datastax.spark.connector.cql.ClusteringColumn;
+// import com.datastax.spark.connector.cql.ColumnDef;
+// import com.datastax.spark.connector.cql.TableDef;
+import com.snowflake.snowpark.Session;
+// import com.datastax.spark.connector.cql.*;
 import zingg.scala.DFUtil;
 
 //import com.datastax.spark.connector.cql.*;
@@ -53,135 +57,138 @@ public class PipeUtil {
 
 	public static final Log LOG = LogFactory.getLog(PipeUtil.class);
 
-	private static DataFrameReader getReader(SparkSession spark, Pipe p) {
-		DataFrameReader reader = spark.read();
+	private static DataFrameReader getReader(Session snow, Pipe p) {
+		DataFrameReader reader = snow.read();
 
-		LOG.warn("Reading input " + p.getFormat().type());
-		reader = reader.format(p.getFormat().type());
-		if (p.getSchema() != null) {
-			reader = reader.schema(p.getSchema());
-		}
-		for (String key : p.getProps().keySet()) {
-			reader = reader.option(key, p.get(key));
-		}
-		reader = reader.option("mode", "PERMISSIVE");
+		// LOG.warn("Reading input " + p.getFormat().type());
+		// reader = reader.format(p.getFormat().type());
+		// if (p.getSchema() != null) {
+		// 	reader = reader.schema(p.getSchema());
+		// }
+		// for (String key : p.getProps().keySet()) {
+		// 	reader = reader.option(key, p.get(key));
+		// }
+		// reader = reader.option("mode", "PERMISSIVE");
 		return reader;
 	}
 
-	private static Dataset<Row> read(DataFrameReader reader, Pipe p, boolean addSource) {
-		Dataset<Row> input = null;
+	private static DataFrame read(DataFrameReader reader, Pipe p, boolean addSource) {
+		DataFrame input = null;
 		LOG.warn("Reading " + p);
 		if (p.getProps().containsKey(FilePipe.LOCATION)) {
-			input = reader.load(p.get(FilePipe.LOCATION));
+			input = reader.json(p.get(FilePipe.LOCATION));
 		}
-		else {
-			input = reader.load();
-		}
+		// else {
+		// 	input = reader.json(p.get(FilePipe.LOCATION));
+		// }
+
 		if (addSource) {
 			input = input.withColumn(ColName.SOURCE_COL, functions.lit(p.getName()));			
 		}
 		return input;
 	}
 
-	private static Dataset<Row> readInternal(SparkSession spark, Pipe p, boolean addSource) {
-		DataFrameReader reader = getReader(spark, p);
+	private static DataFrame readInternal(Session snow, Pipe p, boolean addSource) {
+		DataFrameReader reader = getReader(snow, p);
 		return read(reader, p, addSource);		
 	}
 
-	public static Dataset<Row> joinTrainingSetstoGetLabels(Dataset<Row> jdbc, 
-		Dataset<Row> file)  {
-		file = file.drop(ColName.MATCH_FLAG_COL);
-		file.printSchema();
+	public static DataFrame joinTrainingSetstoGetLabels(DataFrame jdbc, 
+		DataFrame file)  {
+		file = file.drop(new String[] {ColName.MATCH_FLAG_COL});
+		//file.printSchema();
 		file.show();
-		jdbc = jdbc.select(jdbc.col(ColName.ID_COL), jdbc.col(ColName.SOURCE_COL),jdbc.col(ColName.MATCH_FLAG_COL),
-			jdbc.col(ColName.CLUSTER_COLUMN));
-		String[] cols = jdbc.columns();
-		for (int i=0; i < cols.length; ++i) {
-			cols[i] = ColName.COL_PREFIX + cols[i];
-		}
-		jdbc = jdbc.toDF(cols).cache();
 
-		jdbc = jdbc.withColumnRenamed(ColName.COL_PREFIX + ColName.MATCH_FLAG_COL, ColName.MATCH_FLAG_COL);
-		jdbc.printSchema();
+		jdbc = jdbc.select(new Column [] {jdbc.col(ColName.ID_COL), jdbc.col(ColName.SOURCE_COL),jdbc.col(ColName.MATCH_FLAG_COL),
+			jdbc.col(ColName.CLUSTER_COLUMN)});
+		Seq<String> cols = jdbc.schema().names();
+		for (int i=0; i < cols.length(); ++i) {
+			cols.apply(i) = ColName.COL_PREFIX + cols.apply(i);
+		}
+		jdbc = jdbc.toDF(cols).cacheResult();
+
+		jdbc = jdbc.withColumnRenamed(col(ColName.COL_PREFIX + ColName.MATCH_FLAG_COL).as(ColName.MATCH_FLAG_COL));
+		//jdbc.printSchema();
 		jdbc.show();
 		LOG.warn("Building labels ");
-		Dataset<Row> pairs = file.join(jdbc, file.col(ColName.ID_COL).equalTo(
-			jdbc.col(ColName.COL_PREFIX + ColName.ID_COL))
-				.and(file.col(ColName.SOURCE_COL).equalTo(
+		DataFrame pairs = file.join(jdbc, file.col(ColName.ID_COL).equal_to(
+			jdbc.col(ColName.COL_PREFIX + ColName.ID_COL))	
+				.and(file.col(ColName.SOURCE_COL).equal_to(
 					jdbc.col(ColName.COL_PREFIX + ColName.SOURCE_COL)))
-				.and(file.col(ColName.CLUSTER_COLUMN).equalTo(
+				.and(file.col(ColName.CLUSTER_COLUMN).equal_to(
 					jdbc.col(ColName.COL_PREFIX + ColName.CLUSTER_COLUMN))));
 		LOG.warn("Pairs are " + pairs.count());			
 		//in training, we only need that record matches only with lines bigger than itself
 		//in the case of normal as well as in the case of linking
-		pairs = pairs.drop(ColName.COL_PREFIX + ColName.SOURCE_COL);
-		pairs = pairs.drop(ColName.COL_PREFIX + ColName.ID_COL);
-		pairs = pairs.drop(ColName.COL_PREFIX + ColName.CLUSTER_COLUMN);
+		pairs = pairs.drop(new String[] {ColName.COL_PREFIX + ColName.SOURCE_COL});
+		pairs = pairs.drop(new String[] {ColName.COL_PREFIX + ColName.ID_COL});
+		pairs = pairs.drop(new String[] {ColName.COL_PREFIX + ColName.CLUSTER_COLUMN});
 		
 		return pairs;
 	}
 
 
-	private static Dataset<Row> readInternal(SparkSession spark, boolean addLineNo,
+	private static DataFrame readInternal(Session snow, boolean addLineNo,
 			boolean addSource, Pipe... pipes) {
-		Dataset<Row> input = null;
+		DataFrame input = null;
 
 		for (Pipe p : pipes) {
 			if (input == null) {
-				input = readInternal(spark, p, addSource);
+				input = readInternal(snow, p, addSource);
 				LOG.debug("input size is " + input.count());				
 			} else {
 					if (p.get("type") != null && p.get("type").equals("join")) {
 						LOG.warn("joining inputs");
-						Dataset<Row> input1 = readInternal(spark, p, addSource);
+						DataFrame input1 = readInternal(snow, p, addSource);
 						LOG.warn("input now size is " + input1.count());	
 						input = joinTrainingSetstoGetLabels(input, input1 );
 					}
 					else {
-						input = input.union(readInternal(spark, p, addSource));
+						input = input.union(readInternal(snow, p, addSource));
 					}				
 			}
 		}
 		// we will probably need to create row number as string with pipename/id as
 		// suffix
 		if (addLineNo)
-			input = DFUtil.addRowNumber(input, spark);
+			input = DFUtil.addRowNumber(input, snow);
 		// we need to transform the input here by using stop words
 		return input;
 	}
 
-	public static Dataset<Row> read(SparkSession spark, boolean addLineNo, boolean addSource, Pipe... pipes) {
-		Dataset<Row> rows = readInternal(spark, addLineNo, addSource, pipes);
-		rows = rows.persist(StorageLevel.MEMORY_ONLY());
+	public static DataFrame read(Session snow, boolean addLineNo, boolean addSource, Pipe... pipes) {
+		DataFrame rows = readInternal(snow, addLineNo, addSource, pipes);
+		//rows = rows.persist(StorageLevel.MEMORY_ONLY());
 		return rows;
 	}
 
-	public static Dataset<Row> sample(SparkSession spark, Pipe p) {
-		DataFrameReader reader = getReader(spark, p);
+	public static DataFrame sample(Session snow, Pipe p) {
+		DataFrameReader reader = getReader(snow, p);
 		reader.option("inferSchema", true);
 		reader.option("mode", "DROPMALFORMED");
 		LOG.info("reader is ready to sample with inferring " + p.get(FilePipe.LOCATION));
 		LOG.warn("Reading input of type " + p.getFormat().type());
-		Dataset<Row> input = read(reader, p, false);
+		DataFrame input = read(reader, p, false);
 		// LOG.warn("inferred schema " + input.schema());
-		List<Row> values = input.takeAsList(10);
-		values.forEach(r -> LOG.warn(r));
-		Dataset<Row> ret = spark.createDataFrame(values, input.schema());
-		return ret;
+		// List<Row> values = [data for xxx in input.select().toLocalIterator()];
+		// values.forEach(r -> LOG.warn(r));
+		// Seq<Row> seq = JavaConverters.asScalaIteratorConverter(values.iterator()).asScala().toSeq();
+		// DataFrame ret = snow.createDataFrame(seq, null);
+		return input;
 
 	}
 
-	public static Dataset<Row> read(SparkSession spark, boolean addLineNo, int numPartitions,
+	public static DataFrame read(Session snow, boolean addLineNo, int numPartitions,
 			boolean addSource, Pipe... pipes) {
-		Dataset<Row> rows = readInternal(spark, addLineNo, addSource, pipes);
-		rows = rows.repartition(numPartitions);
-		rows = rows.persist(StorageLevel.MEMORY_ONLY());
+		DataFrame rows = readInternal(snow, addLineNo, addSource, pipes);
+		//rows = rows.repartition(numPartitions);
+		//rows = rows.persist(StorageLevel.MEMORY_ONLY());
 		return rows;
 	}
 
-	public static void write(Dataset<Row> toWriteOrig, Arguments args, JavaSparkContext ctx, Pipe... pipes) {
+	public static void write(DataFrame toWriteOrig, Arguments args, String ctx, Pipe... pipes) {
 			for (Pipe p: pipes) {
-			Dataset<Row> toWrite = toWriteOrig;
+			DataFrame toWrite = toWriteOrig;
 			DataFrameWriter writer = toWrite.write();
 		
 			LOG.warn("Writing output " + p);
@@ -193,20 +200,20 @@ public class PipeUtil {
 				writer.mode("Append");
 			}
 			if (p.getFormat().equals(Format.ELASTIC)) {
-				ctx.getConf().set(ElasticPipe.NODE, p.getProps().get(ElasticPipe.NODE));
-				ctx.getConf().set(ElasticPipe.PORT, p.getProps().get(ElasticPipe.PORT));
-				ctx.getConf().set(ElasticPipe.ID, ColName.ID_COL);
-				ctx.getConf().set(ElasticPipe.RESOURCE, p.getName());
+				// ctx.getConf().set(ElasticPipe.NODE, p.getProps().get(ElasticPipe.NODE));
+				// ctx.getConf().set(ElasticPipe.PORT, p.getProps().get(ElasticPipe.PORT));
+				// ctx.getConf().set(ElasticPipe.ID, ColName.ID_COL);
+				// ctx.getConf().set(ElasticPipe.RESOURCE, p.getName());
 			}
-			writer = writer.format(p.getFormat().type());
+			//writer = writer.format(p.getFormat().type());
 			
 			for (String key: p.getProps().keySet()) {
-				writer = writer.option(key, p.get(key));
+				//writer = writer.option(key, p.get(key));
 			}
 			if (p.getFormat() == Format.CASSANDRA) {
 				/*
 				ctx.getConf().set(CassandraPipe.HOST, p.getProps().get(CassandraPipe.HOST));
-				toWrite.sparkSession().conf().set(CassandraPipe.HOST, p.getProps().get(CassandraPipe.HOST));
+				toWrite.snowSession().conf().set(CassandraPipe.HOST, p.getProps().get(CassandraPipe.HOST));
 				//df.createCassandraTable(p.get("keyspace"), p.get("table"), opPk, opCl, CassandraConnector.apply(ctx.getConf()));
 				
 				CassandraConnector connector = CassandraConnector.apply(ctx.getConf());
@@ -252,11 +259,11 @@ public class PipeUtil {
 			}
 			else if (p.getProps().containsKey("location")) {
 				LOG.warn("Writing file");
-				writer.save(p.get(FilePipe.LOCATION));
+				writer.saveAsTable(p.get(FilePipe.LOCATION));
 			}	
 			else if (p.getFormat().equals(Format.JDBC)){
 				writer = toWrite.write();
-				writer = writer.format(p.getFormat().type());				
+				//writer = writer.format(p.getFormat().type());				
 
 				if (p.getMode() != null) {
 					writer.mode(p.getMode());
@@ -265,12 +272,12 @@ public class PipeUtil {
 					writer.mode("Append");
 				}
 				for (String key: p.getProps().keySet()) {
-					writer = writer.option(key, p.get(key));
+					//writer = writer.option(key, p.get(key));
 				}
-				writer.save();
+				writer.saveAsTable("jdbc_tableA");
 			}
 			else {			
-				writer.save();
+				writer.saveAsTable("general_table");
 			
 			}
 			
@@ -279,11 +286,11 @@ public class PipeUtil {
 
 	}
 
-	public static void writePerSource(Dataset<Row> toWrite, Arguments args, JavaSparkContext ctx, Pipe[] pipes ) {
-		List<Row> sources = toWrite.select(ColName.SOURCE_COL).distinct().collectAsList();
+	public static void writePerSource(DataFrame toWrite, Arguments args, String ctx, Pipe[] pipes ) {
+		Row[] sources = toWrite.select(new String[] {ColName.SOURCE_COL}).distinct().collect();
 		for (Row r : sources) {
-			Dataset<Row> toWriteNow = toWrite.filter(toWrite.col(ColName.SOURCE_COL).equalTo(r.get(0)));
-			toWriteNow = toWriteNow.drop(ColName.SOURCE_COL);
+			DataFrame toWriteNow = toWrite.filter(toWrite.col(ColName.SOURCE_COL).equal_to((Column)r.get(0)));
+			toWriteNow = toWriteNow.drop(new String[] {ColName.SOURCE_COL});
 			PipeUtil.write(toWriteNow, args, ctx, pipes);
 
 		}
@@ -314,7 +321,7 @@ public class PipeUtil {
 		Pipe p = new Pipe();
 		p.setFormat(Format.PARQUET);
 		p.setProp(FilePipe.LOCATION, args.getBlockFile());
-		p.setMode(SaveMode.Overwrite);
+		p.setMode(SaveMode.Append$);
 		return p;
 	}
 
@@ -328,7 +335,7 @@ public class PipeUtil {
 	}
 
 	/*
-	 * public static String getTableCreateCQL(Pipe p, Dataset<Row> df) {
+	 * public static String getTableCreateCQL(Pipe p, DataFrame df) {
 	 * 
 	 * Set<String> partitionKeys = new TreeSet<String>() { {
 	 * add(p.get(CassandraPipe.PRIMARY_KEY)); } }; int c = 0; Map<String, Integer>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 		<zingg.version>0.3.2-SNAPSHOT</zingg.version>
 		<skipTests>true</skipTests>
 		<failIfNoTests>false</failIfNoTests>
-		<maven.compiler.source>8</maven.compiler.source>
-		<maven.compiler.target>8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<mcheckstyle.version>2.10</mcheckstyle.version>
 		<mfindbugs.version>2.5.2</mfindbugs.version>
@@ -111,6 +111,12 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.snowflake</groupId>
+			<artifactId>snowpark</artifactId>
+			<version>1.0.0</version>
+			<scope>compile</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch-spark-20_2.11</artifactId>


### PR DESCRIPTION
Few Points:
Compiler version - java 11 (Fixed)
Scala version 2.12.11 and above

* simple df.col(x) is not present. Also no Columns().... in snowspark, it has to get something like df.schema().names() ...  need to work further on this.
* collectAsList() is not present. rather, need to use collect(): Seq and get the needful done.
* read and write are simpler. Perhaps, most of the time have to be writeToTable() for core data.