### PR TITLE
--snowflake option added to take connection paramters

### DIFF
--- a/client/src/main/java/zingg/client/Arguments.java
+++ b/client/src/main/java/zingg/client/Arguments.java
@@ -102,7 +102,8 @@ public class Arguments implements Serializable {
 	String modelId = "1";
 	double threshold = 0.5d;
 	int jobId = 1;
-	boolean collectMetrics = true; 
+	boolean collectMetrics = true;
+	String snowflake = "";
 	
 	private static final String ENV_VAR_MARKER_START = "$";
 	private static final String ENV_VAR_MARKER_END = "$";
@@ -596,6 +597,14 @@ public class Arguments implements Serializable {
 
 	public void setCollectMetrics(boolean collectMetrics) {
 		this.collectMetrics = collectMetrics;
+	}
+
+	public String getSnowflake() {
+		return snowflake;
+	}
+
+	public void setSnowflake(String snowflake) {
+		this.snowflake = snowflake;
 	}
 
 	public String[] getPipeNames() {

--- a/client/src/main/java/zingg/client/Client.java
+++ b/client/src/main/java/zingg/client/Client.java
@@ -86,6 +86,11 @@ public class Client implements Serializable {
 			String j = options.get(options.COLLECT_METRICS).value;
 			args.setCollectMetrics(Boolean.valueOf(j));
 		}
+		if (options.get(options.SNOWFLAKE)!= null) {
+			LOG.info("Using snowflake connect parameters file from command line");
+			String j = options.get(options.SNOWFLAKE).value;
+			args.setSnowflake(j);
+		}
 		setArguments(args);
 	}
 	

--- a/client/src/main/java/zingg/client/ClientOptions.java
+++ b/client/src/main/java/zingg/client/ClientOptions.java
@@ -56,7 +56,7 @@ public class ClientOptions {
 		optionMaster.put(ZINGG_DIR, new Option(ZINGG_DIR, true, "location of Zingg models, defaults to /tmp/zingg", false, false));
 		optionMaster.put(MODEL_ID, new Option(MODEL_ID, true, "model identifier, can be a number ", false, false));
 		optionMaster.put(COLLECT_METRICS, new Option(COLLECT_METRICS, true, "collect analytics, true/false  ", false, false));
-		optionMaster.put(SNOWFLAKE, new Option(SNOWFLAKE, true, "snowflake connect parameters in a json file", false, false));
+		optionMaster.put(SNOWFLAKE, new Option(SNOWFLAKE, true, "snowflake connect parameters in a properties file", false, false));
 				
 		//no args
 		optionMaster.put(HELP,new Option(HELP,  false, "print usage information", true, false));

--- a/client/src/main/java/zingg/client/ClientOptions.java
+++ b/client/src/main/java/zingg/client/ClientOptions.java
@@ -27,6 +27,7 @@ public class ClientOptions {
 	public static final String ZINGG_DIR = "--zinggDir";
 	public static final String MODEL_ID = "--modelId";
 	public static final String COLLECT_METRICS = "--collectMetrics";
+	public static final String SNOWFLAKE = "--snowflake";
 	
 	 // Options that do not take arguments.
 	public static final String HELP = "--help";
@@ -55,6 +56,7 @@ public class ClientOptions {
 		optionMaster.put(ZINGG_DIR, new Option(ZINGG_DIR, true, "location of Zingg models, defaults to /tmp/zingg", false, false));
 		optionMaster.put(MODEL_ID, new Option(MODEL_ID, true, "model identifier, can be a number ", false, false));
 		optionMaster.put(COLLECT_METRICS, new Option(COLLECT_METRICS, true, "collect analytics, true/false  ", false, false));
+		optionMaster.put(SNOWFLAKE, new Option(SNOWFLAKE, true, "snowflake connect parameters in a json file", false, false));
 				
 		//no args
 		optionMaster.put(HELP,new Option(HELP,  false, "print usage information", true, false));

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 		<zingg.version>0.3.2-SNAPSHOT</zingg.version>
 		<skipTests>true</skipTests>
 		<failIfNoTests>false</failIfNoTests>
-		<maven.compiler.source>8</maven.compiler.source>
-		<maven.compiler.target>8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<mcheckstyle.version>2.10</mcheckstyle.version>
 		<mfindbugs.version>2.5.2</mfindbugs.version>
@@ -111,6 +111,12 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.snowflake</groupId>
+			<artifactId>snowpark</artifactId>
+			<version>1.0.0</version>
+			<scope>compile</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch-spark-20_2.11</artifactId>
@@ -228,6 +234,12 @@
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.1.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.crealytics/spark-excel -->
+		<dependency>
+			<groupId>com.crealytics</groupId>
+			<artifactId>spark-excel_${scala.binary.version}</artifactId>
+			<version>3.1.2_0.16.5-pre1</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
New option to take connection parameters for snowflake.
The parameters can be refer to at https://docs.snowflake.com/en/developer-guide/snowpark/creating-session.html
e.g.
```
# profile.properties file (a text file)
URL = https://<account_identifier>.snowflakecomputing.com
USER = <username>
PRIVATE_KEY_FILE = </path/to/private_key_file.p8>
PRIVATE_KEY_FILE_PWD = <if the private key is encrypted, set this to the passphrase for decrypting the key>
ROLE = <role_name>
WAREHOUSE = <warehouse_name>
DB = <database_name>
SCHEMA = <schema_name>
```