### PR TITLE
 snowflake_java based apis

### DIFF
--- a/client/src/main/java/zingg/client/Arguments.java
+++ b/client/src/main/java/zingg/client/Arguments.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.scala.DefaultScalaModule;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -245,7 +244,7 @@ public class Arguments implements Serializable {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
 					true);
-			mapper.registerModule(new DefaultScalaModule());
+			//mapper.registerModule(new DefaultScalaModule());
 			mapper.writerWithDefaultPrettyPrinter().writeValue(new File(filePath), args);
 		}
 		catch(Exception e) {

--- a/client/src/main/java/zingg/client/Client.java
+++ b/client/src/main/java/zingg/client/Client.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.api.java.JavaSparkContext;
 
 import zingg.client.util.Email;
 import zingg.client.util.EmailBody;
@@ -48,7 +47,7 @@ public class Client implements Serializable {
 	}
 
 	public void setZingg(Arguments args, ClientOptions options) throws Exception{
-		JavaSparkContext.jarOfClass(IZinggFactory.class);
+		//JavaSparkContext.jarOfClass(IZinggFactory.class);
 		IZinggFactory zf = (IZinggFactory) Class.forName("zingg.ZFactory").newInstance();
 		setZingg(zf.get(ZinggOptions.getByValue(options.get(ClientOptions.PHASE).value.trim())));
 	}

--- a/client/src/main/java/zingg/client/FieldDefinition.java
+++ b/client/src/main/java/zingg/client/FieldDefinition.java
@@ -5,12 +5,13 @@ import java.io.Serializable;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.types.DataType;
+import com.snowflake.snowpark_java.types.DataType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.jsontype.*;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -65,7 +66,7 @@ public class FieldDefinition implements
 
 	@JsonProperty("dataType")
 	public void setDataType(String d) {
-		if (d!= null) this.dataType =  DataType.fromJson(d);
+		//if (d!= null) this.dataType =  d;
 	}
 	
 	
@@ -122,7 +123,7 @@ public class FieldDefinition implements
 	    public void serialize(DataType dType, JsonGenerator jsonGenerator, 
 	        SerializerProvider serializerProvider) 
 	        		throws IOException, JsonProcessingException {
-				jsonGenerator.writeString(dType.json());
+				jsonGenerator.writeString(dType.typeName());
 	        
 		}
 	}

--- a/client/src/main/java/zingg/client/pipe/FilePipe.java
+++ b/client/src/main/java/zingg/client/pipe/FilePipe.java
@@ -3,6 +3,7 @@ package zingg.client.pipe;
 public class FilePipe extends Pipe{
 	
 	public static final String LOCATION = "location";
+	public static final String TABLENAME = "tableName";
 	
 	public FilePipe(Pipe p) {
 		clone(p);

--- a/client/src/main/java/zingg/client/pipe/FilePipe.java
+++ b/client/src/main/java/zingg/client/pipe/FilePipe.java
@@ -3,7 +3,6 @@ package zingg.client.pipe;
 public class FilePipe extends Pipe{
 	
 	public static final String LOCATION = "location";
-	public static final String TABLENAME = "tableName";
 	
 	public FilePipe(Pipe p) {
 		clone(p);

--- a/client/src/main/java/zingg/client/pipe/Format.java
+++ b/client/src/main/java/zingg/client/pipe/Format.java
@@ -13,13 +13,8 @@ public enum Format implements Serializable{
 	CSV ("csv"),
 	JSON("json"),
 	JDBC("jdbc"),
-	ELASTIC("org.elasticsearch.spark.sql"),
-	CASSANDRA("org.apache.spark.sql.cassandra"),
-	XLS("com.crealytics.spark.excel"),
-	XLSX("com.crealytics.spark.excel"),
 	PARQUET("PARQUET"),
 	AVRO("avro"),
-	SNOWFLAKE("net.snowflake.spark.snowflake"),
 	TEXT("text");
 	
 	String type;

--- a/client/src/main/java/zingg/client/pipe/Pipe.java
+++ b/client/src/main/java/zingg/client/pipe/Pipe.java
@@ -5,9 +5,9 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.spark.sql.SaveMode;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.StructType;
+import com.snowflake.snowpark_java.SaveMode;
+import com.snowflake.snowpark_java.types.StructType;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonValue;
 
@@ -91,7 +91,7 @@ public class Pipe implements Serializable{
 	
 	@JsonProperty("schema")
 	public void setSchema(String s) {
-		if (s!= null) this.schema = (StructType) DataType.fromJson(s);
+		//TODO-SNOW //if (s!= null) this.schema = s ;
 		//schema = DataTypes.createStructType(s);
 	}
 	
@@ -169,7 +169,7 @@ public class Pipe implements Serializable{
 	    public void serialize(
 	    		StructType value, JsonGenerator gen, SerializerProvider arg2) 
 	      throws IOException, JsonProcessingException {
-	        gen.writeObject(value.json());
+	        //TODO-SNOW gen.writeObject(value.json());
 	    }
 	}
 

--- a/client/src/main/java/zingg/client/pipe/Pipe.java
+++ b/client/src/main/java/zingg/client/pipe/Pipe.java
@@ -35,7 +35,7 @@ public class Pipe implements Serializable{
 	Map<String, String> props;
 	@JsonSerialize(using = CustomSchemaSerializer.class)
 	StructType schema = null;
-	Map<String, String> sparkProps;
+	Map<String, String> snowProps;
 	Map<String, String> addProps;
 	SaveMode mode;
 	int id;
@@ -86,7 +86,7 @@ public class Pipe implements Serializable{
 		this.name = p.name;
 		this.format = p.format;
 		this.props = p.props;
-		this.sparkProps = p.sparkProps;
+		this.snowProps = p.snowProps;
 	}
 	
 	@JsonProperty("schema")
@@ -124,13 +124,13 @@ public class Pipe implements Serializable{
 	}
 
 
-	public Map<String, String> getSparkProps() {
-		return sparkProps;
+	public Map<String, String> getSnowProps() {
+		return snowProps;
 	}
 
 
-	public void setSparkProps(Map<String, String> sparkProps) {
-		this.sparkProps = sparkProps;
+	public void setSnowProps(Map<String, String> snowProps) {
+		this.snowProps = snowProps;
 	}
 
 	
@@ -190,7 +190,7 @@ public class Pipe implements Serializable{
 		p.preprocessors = preprocessors;
 		p.props = props;
 		p.schema = schema;
-		p.sparkProps = sparkProps;
+		p.snowProps = snowProps;
 		p.addProps = addProps;
 		p.mode = mode;
 		p.id = id;

--- a/client/src/main/java/zingg/client/pipe/PipeFactory.java
+++ b/client/src/main/java/zingg/client/pipe/PipeFactory.java
@@ -27,13 +27,6 @@ public class PipeFactory {
 			switch (p.format) {
 			case CSV:
 			case JSON:
-			case XLS:
-			case XLSX:
-				return new FilePipe(p);
-			case CASSANDRA:
-				return p;
-			case ELASTIC:
-				return p;
 			case JDBC:
 				return new JdbcPipe(p);
 			default:

--- a/client/src/main/java/zingg/client/pipe/SnowPipe.java
+++ b/client/src/main/java/zingg/client/pipe/SnowPipe.java
@@ -1,0 +1,9 @@
+package zingg.client.pipe;
+
+public class SnowPipe extends Pipe {
+	public static final String TABLENAME = "tableName";
+
+	public SnowPipe(Pipe p) {
+		clone(p);
+	}
+}

--- a/client/src/main/java/zingg/client/util/Util.java
+++ b/client/src/main/java/zingg/client/util/Util.java
@@ -27,10 +27,6 @@ import com.snowflake.snowpark_java.Functions;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 public class Util implements Serializable {
 
@@ -422,36 +418,6 @@ public class Util implements Serializable {
 		}
 		return functions;
 	}*/
-	
-	
-	
-		
-	public static String getNextLabelPath(String path) throws IOException {
-		Configuration conf = new Configuration();
-		FileSystem fs = FileSystem.get(conf);
-		Path fsPath = new Path(path);
-		String pathPrefix = "";
-		if (!fs.exists(fsPath)) {
-			pathPrefix += "0";
-		}
-		else {
-			FileStatus[] fileStatus = fs.listStatus(fsPath);
-			pathPrefix += fileStatus.length;
-		}
-		return pathPrefix;
-		
-	}
-	
-	public static String getCurrentLabelPath(String path) throws IOException {
-		Configuration conf = new Configuration();
-		FileSystem fs = FileSystem.get(conf);
-		Path fsPath = new Path(path);
-		int pathPrefix = 0;
-		FileStatus[] fileStatus = fs.listStatus(fsPath);
-		pathPrefix = fileStatus.length -1;
-		return new Integer(pathPrefix).toString();
-		
-	}
 	
 	public static DataFrame addUniqueCol(DataFrame dupesActual, String colName) {
 		String append = System.currentTimeMillis() + ":";

--- a/client/src/main/java/zingg/client/util/Util.java
+++ b/client/src/main/java/zingg/client/util/Util.java
@@ -22,24 +22,15 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Functions;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.SparkContext;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataType;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
-import zingg.client.util.ListMap;
 
 public class Util implements Serializable {
 
@@ -462,12 +453,12 @@ public class Util implements Serializable {
 		
 	}
 	
-	public static Dataset<Row> addUniqueCol(Dataset<Row> dupesActual, String colName) {
+	public static DataFrame addUniqueCol(DataFrame dupesActual, String colName) {
 		String append = System.currentTimeMillis() + ":";
 		dupesActual = dupesActual.withColumn(colName + "temp", 
-				functions.lit(append));
+				Functions.lit(append));
 		dupesActual = dupesActual.withColumn(colName,
-				functions.concat(dupesActual.col(colName + "temp"),
+				Functions.concat(dupesActual.col(colName + "temp"),
 						dupesActual.col(colName)));
 		dupesActual = dupesActual.drop(dupesActual.col(colName + "temp"));
 		return dupesActual;

--- a/client/src/main/resources/log4j.properties
+++ b/client/src/main/resources/log4j.properties
@@ -19,7 +19,6 @@ log4j.logger.org.apache.poi=INFO
 log4j.logger.io.netty=OFF
 log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.spark=WARN, FILE
-log4j.logger.org.apache.spark.ml=INFO, FILE
 log4j.logger.org.apache.parquet.hadoop=WARN, FILE
 log4j.logger.org.graphframes=WARN, FILE
 log4j.logger.org.spark_project=OFF

--- a/core/src/main/java/zingg/LabelUpdater.java
+++ b/core/src/main/java/zingg/LabelUpdater.java
@@ -7,14 +7,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import com.snowflake.snowpark_java.Column;
 import com.snowflake.snowpark_java.DataFrame;
-import com.snowflake.snowpark_java.Row;
 import com.snowflake.snowpark_java.SaveMode;
+import com.snowflake.snowpark_java.Functions;
 
 import zingg.client.ZinggClientException;
 import zingg.client.ZinggOptions;
 import zingg.client.pipe.Pipe;
 import zingg.client.util.ColName;
-import zingg.client.util.ColValues;
 import zingg.util.DSUtil;
 import zingg.util.LabelMatchType;
 import zingg.util.PipeUtil;
@@ -70,7 +69,7 @@ public class LabelUpdater extends Labeller {
 					continue;
 				}
 
-				matchFlag = currentPair.first().getAs(ColName.MATCH_FLAG_COL);
+				matchFlag = currentPair.first().get().getInt(DSUtil.getIndex(currentPair, ColName.MATCH_FLAG_COL));
 				String preMsg = String.format("\n\tThe record pairs belonging to the input cluster id %s are:", cluster_id);
 				String matchType = LabelMatchType.get(matchFlag).msg;
 				postMsg = String.format("\tThe above pair is labeled as %s\n", matchType);
@@ -83,10 +82,10 @@ public class LabelUpdater extends Labeller {
 					break;
 				}
 				recordsToUpdate = recordsToUpdate
-						.filter(recordsToUpdate.col(ColName.CLUSTER_COLUMN).notEqual(cluster_id));
+						.filter(recordsToUpdate.col(ColName.CLUSTER_COLUMN).not_equal(Functions.lit(cluster_id)));
 				if (updatedRecords != null) {
 					updatedRecords = updatedRecords
-							.filter(updatedRecords.col(ColName.CLUSTER_COLUMN).notEqual(cluster_id));
+							.filter(updatedRecords.col(ColName.CLUSTER_COLUMN).not_equal(Functions.lit(cluster_id)));
 				}
 				updatedRecords = updateRecords(selectedOption, currentPair, updatedRecords);
 			} while (selectedOption != 9);

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -85,8 +85,9 @@ public class Labeller extends ZinggBase {
 
 		lines = lines.cacheResult();
 		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false);
-
-		List<Row> clusterIDs = Arrays.asList(lines.select(ColName.CLUSTER_COLUMN).distinct().collect());
+		DataFrame clusters = lines.select(ColName.CLUSTER_COLUMN);
+		int clusterColumnIndex = DSUtil.getIndex(clusters, ColName.CLUSTER_COLUMN);
+		List<Row> clusterIDs = Arrays.asList(clusters.distinct().collect());
 		try {
 			double score;
 			double prediction;
@@ -97,7 +98,7 @@ public class Labeller extends ZinggBase {
 			
 			for (int index = 0; index < totalPairs; index++){	
 				DataFrame currentPair = lines.filter(lines.col(ColName.CLUSTER_COLUMN).equal_to(
-					Functions.lit(clusterIDs.get(index).get(0)))).cacheResult();
+					Functions.lit(clusterIDs.get(index).get(clusterColumnIndex)))).cacheResult();
 				
 				score = (Double)currentPair.first().get().get(DSUtil.getIndex(currentPair, ColName.SCORE_COL));
 				prediction = (Double)currentPair.first().get().get(DSUtil.getIndex(currentPair, ColName.PREDICTION_COL));

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -211,7 +211,7 @@ public class Labeller extends ZinggBase {
 			LOG.warn("No records to be labelled.");
 			return;
 		}		
-		PipeUtil.write(records, args, ctx, getOutputPipe());
+		PipeUtil.write(records, args, getOutputPipe());
 	}
 
 	protected Pipe getOutputPipe() {

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -7,16 +7,17 @@ import java.util.Scanner;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
+import com.snowflake.snowpark_java.Column;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Functions;
 
 import zingg.client.ZinggClientException;
 import zingg.client.ZinggOptions;
 import zingg.client.pipe.Pipe;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
+import zingg.client.util.Util;
 import zingg.util.DSUtil;
 import zingg.util.PipeUtil;
 import zingg.util.LabelMatchType;
@@ -35,7 +36,7 @@ public class Labeller extends ZinggBase {
 	public void execute() throws ZinggClientException {
 		try {
 			LOG.info("Reading inputs for labelling phase ...");
-			Dataset<Row> unmarkedRecords = getUnmarkedRecords();
+			DataFrame unmarkedRecords = getUnmarkedRecords();
 			processRecordsCli(unmarkedRecords);
 			LOG.info("Finished labelling phase");
 		} catch (Exception e) {
@@ -44,19 +45,19 @@ public class Labeller extends ZinggBase {
 		}
 	}
 
-	public Dataset<Row> getUnmarkedRecords() throws ZinggClientException {
-		Dataset<Row> unmarkedRecords = null;
-		Dataset<Row> markedRecords = null;
+	public DataFrame getUnmarkedRecords() throws ZinggClientException {
+		DataFrame unmarkedRecords = null;
+		DataFrame markedRecords = null;
 		try {
-			unmarkedRecords = PipeUtil.read(spark, false, false, PipeUtil.getTrainingDataUnmarkedPipe(args));
+			unmarkedRecords = PipeUtil.read(snow, false, false, PipeUtil.getTrainingDataUnmarkedPipe(args));
 			try {
-				markedRecords = PipeUtil.read(spark, false, false, PipeUtil.getTrainingDataMarkedPipe(args));
+				markedRecords = PipeUtil.read(snow, false, false, PipeUtil.getTrainingDataMarkedPipe(args));
 			} catch (Exception e) {
 				LOG.warn("No record has been marked yet");
 			}
 			if (markedRecords != null ) {
 				unmarkedRecords = unmarkedRecords.join(markedRecords,
-						unmarkedRecords.col(ColName.CLUSTER_COLUMN).equalTo(markedRecords.col(ColName.CLUSTER_COLUMN)),
+						unmarkedRecords.col(ColName.CLUSTER_COLUMN).in(markedRecords.col(ColName.CLUSTER_COLUMN)),
 						"left_anti");
 						getMarkedRecordsStat(markedRecords);
 			} 
@@ -66,14 +67,14 @@ public class Labeller extends ZinggBase {
 		return unmarkedRecords;
 	}
 
-	protected void getMarkedRecordsStat(Dataset<Row> markedRecords) {
-		positivePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).equalTo(ColValues.MATCH_TYPE_MATCH)).count() / 2;
-		negativePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).equalTo(ColValues.MATCH_TYPE_NOT_A_MATCH)).count() / 2;
-		notSurePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).equalTo(ColValues.MATCH_TYPE_NOT_SURE)).count() / 2;
+	protected void getMarkedRecordsStat(DataFrame markedRecords) {
+		positivePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_MATCH)).count() / 2;
+		negativePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_NOT_A_MATCH)).count() / 2;
+		notSurePairsCount = markedRecords.filter(markedRecords.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_NOT_SURE)).count() / 2;
 		totalCount = markedRecords.count() / 2;
 	}
 
-	public void processRecordsCli(Dataset<Row> lines) throws ZinggClientException {
+	public void processRecordsCli(DataFrame lines) throws ZinggClientException {
 		LOG.info("Processing Records for CLI Labelling");
 		printMarkedRecordsStat();
 		if (lines == null || lines.count() == 0) {
@@ -81,24 +82,24 @@ public class Labeller extends ZinggBase {
 			return;
 		}
 
-		lines = lines.cache();
+		lines = lines.cacheResult();
 		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false);
 
-		List<Row> clusterIDs = lines.select(ColName.CLUSTER_COLUMN).distinct().collectAsList();
+		List<Row> clusterIDs = Arrays.asList(lines.select(ColName.CLUSTER_COLUMN).distinct().collect());
 		try {
 			double score;
 			double prediction;
-			Dataset<Row> updatedRecords = null;
+			DataFrame updatedRecords = null;
 			int selected_option = -1;
 			String msg1, msg2;
 			int totalPairs = clusterIDs.size();
 			
 			for (int index = 0; index < totalPairs; index++){	
-				Dataset<Row> currentPair = lines.filter(lines.col(ColName.CLUSTER_COLUMN).equalTo(
-						clusterIDs.get(index).getAs(ColName.CLUSTER_COLUMN))).cache();
+				DataFrame currentPair = lines.filter(lines.col(ColName.CLUSTER_COLUMN).in(
+						clusterIDs.get(index).getAs(ColName.CLUSTER_COLUMN))).cacheResult();
 				
-				score = currentPair.head().getAs(ColName.SCORE_COL);
-				prediction = currentPair.head().getAs(ColName.PREDICTION_COL);
+				score = currentPair.sample(1).getAs(ColName.SCORE_COL);
+				prediction = currentPair.first().getAs(ColName.PREDICTION_COL);
 	
 				msg1 = String.format("\tCurrent labelling round  : %d/%d pairs labelled\n", index, totalPairs);
 				String matchType = LabelMatchType.get(prediction).msg;				
@@ -133,18 +134,18 @@ public class Labeller extends ZinggBase {
 	}
 
 	
-	protected int displayRecordsAndGetUserInput(Dataset<Row> records, String preMessage, String postMessage) {
+	protected int displayRecordsAndGetUserInput(DataFrame records, String preMessage, String postMessage) {
 		//System.out.println();
 		System.out.println(preMessage);
-		records.show(false);
+		records.show();
 		System.out.println(postMessage);
 		System.out.println("\tWhat do you think? Your choices are: ");
 		int selection = readCliInput();
 		return selection;
 	}
 
-	protected Dataset<Row> updateRecords(int matchValue, Dataset<Row> newRecords, Dataset<Row> updatedRecords) {
-		newRecords = newRecords.withColumn(ColName.MATCH_FLAG_COL, functions.lit(matchValue));
+	protected DataFrame updateRecords(int matchValue, DataFrame newRecords, DataFrame updatedRecords) {
+		newRecords = newRecords.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(matchValue));
 		if (updatedRecords == null) {
 			updatedRecords = newRecords;
 		} else {
@@ -203,7 +204,7 @@ public class Labeller extends ZinggBase {
 		System.out.println(msg);
 	}
 
-	protected void writeLabelledOutput(Dataset<Row> records) {
+	protected void writeLabelledOutput(DataFrame records) {
 		if (records == null) {
 			LOG.warn("No records to be labelled.");
 			return;

--- a/core/src/main/java/zingg/Linker.java
+++ b/core/src/main/java/zingg/Linker.java
@@ -61,7 +61,7 @@ public class Linker extends Matcher {
 				dupesActual = Util.addUniqueCol(dupesActual, ColName.ID_COL);
 				DataFrame dupes2 = DSUtil.alignLinked(dupesActual, args);
 				LOG.debug("uncertain output schema is " + dupes2.schema());
-				PipeUtil.write(dupes2, args, ctx, args.getOutput());
+				PipeUtil.write(dupes2, args, args.getOutput());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/core/src/main/java/zingg/Matcher.java
+++ b/core/src/main/java/zingg/Matcher.java
@@ -5,13 +5,11 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
-import org.apache.spark.sql.expressions.Window;
-import org.apache.spark.sql.expressions.WindowSpec;
+import com.snowflake.snowpark_java.Column;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Functions;
+import static com.snowflake.snowpark_java.Functions.col;
 
 import scala.collection.JavaConverters;
 import zingg.block.Block;
@@ -41,74 +39,75 @@ public class Matcher extends ZinggBase{
         setZinggOptions(ZinggOptions.MATCH);
     }
 
-	protected Dataset<Row> getTestData() {
-		return PipeUtil.read(spark, true, args.getNumPartitions(), true, args.getData());
+	protected DataFrame getTestData() {
+		return PipeUtil.read(snow, true, args.getNumPartitions(), true, args.getData());
 	}
 
-	protected Dataset<Row> getBlocked(Dataset<Row> testData) throws Exception{
+	protected DataFrame getBlocked(DataFrame testData) throws Exception{
 		LOG.debug("Blocking model file location is " + args.getBlockFile());
-		Tree<Canopy> tree = BlockingTreeUtil.readBlockingTree(spark, args);
-		Dataset<Row> blocked = testData.map(new Block.BlockFunction(tree), RowEncoder.apply(Block.appendHashCol(testData.schema())));
-		Dataset<Row> blocked1 = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)); //.cache();
+		Tree<Canopy> tree = BlockingTreeUtil.readBlockingTree(snow, args);
+		DataFrame blocked = testData.map(new Block.BlockFunction(tree), RowEncoder.apply(Block.appendHashCol(testData.schema())));
+		//DataFrame blocked1 = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)); //.cacheResult();
+		DataFrame blocked1 = blocked;
 		return blocked1;
 	}
 
-	protected Dataset<Row> getBlocks(Dataset<Row> blocked) throws Exception{
-		return DSUtil.joinWithItself(blocked, ColName.HASH_COL, true).cache();
+	protected DataFrame getBlocks(DataFrame blocked) throws Exception{
+		return DSUtil.joinWithItself(blocked, ColName.HASH_COL, true).cacheResult();
 	}
 
-	protected Dataset<Row> getBlocks(Dataset<Row> blocked, Dataset<Row> bAll) throws Exception{
-		//Dataset<Row> joinH = DSUtil.joinWithItself(blocked, ColName.HASH_COL, true).cache();
-		Dataset<Row> joinH = blocked.as("first").join(blocked.as("second"), ColName.HASH_COL)
+	protected DataFrame getBlocks(DataFrame blocked, DataFrame bAll) throws Exception{
+		//DataFrame joinH = DSUtil.joinWithItself(blocked, ColName.HASH_COL, true).cacheResult();
+		DataFrame joinH = blocked.as("first").join(blocked.as("second"), ColName.HASH_COL)
 			.selectExpr("first.z_zid as z_zid", "second.z_zid as z_z_zid");
 		joinH.show();
 		joinH = joinH.filter(joinH.col(ColName.ID_COL).gt(joinH.col(ColName.COL_PREFIX + ColName.ID_COL)));	
 		LOG.warn("Num comparisons " + joinH.count());
-		joinH = joinH.repartition(args.getNumPartitions(), joinH.col(ColName.ID_COL));
-		bAll = bAll.repartition(args.getNumPartitions(), bAll.col(ColName.ID_COL));
+		//joinH = joinH.repartition(args.getNumPartitions(), joinH.col(ColName.ID_COL));
+		//bAll = bAll.repartition(args.getNumPartitions(), bAll.col(ColName.ID_COL));
 		joinH = joinH.join(bAll, ColName.ID_COL);
 		LOG.warn("Joining with actual values");
 		//joinH.show();
 		bAll = DSUtil.getPrefixedColumnsDS(bAll);
 		//bAll.show();
-		joinH = joinH.repartition(args.getNumPartitions(), joinH.col(ColName.COL_PREFIX + ColName.ID_COL));
+		//joinH = joinH.repartition(args.getNumPartitions(), joinH.col(ColName.COL_PREFIX + ColName.ID_COL));
 		joinH = joinH.join(bAll, ColName.COL_PREFIX + ColName.ID_COL);
 		LOG.warn("Joining again with actual values");
 		//joinH.show();
 		return joinH;
 	}
 
-	protected Dataset<Row> massageAllEquals(Dataset<Row> allEqual) {
+	protected DataFrame massageAllEquals(DataFrame allEqual) {
 		allEqual = allEqual.withColumn(ColName.PREDICTION_COL, 
-			functions.lit(ColValues.IS_MATCH_PREDICTION));
-		allEqual = allEqual.withColumn(ColName.SCORE_COL, functions.lit(ColValues.FULL_MATCH_SCORE));
+			Functions.lit(ColValues.IS_MATCH_PREDICTION));
+		allEqual = allEqual.withColumn(ColName.SCORE_COL, Functions.lit(ColValues.FULL_MATCH_SCORE));
 		return allEqual;
 	}
 
 	protected Model getModel() {
 		Model model = new Model(this.featurers);
-		model.register(spark);
+		model.register(snow);
 		model.load(args.getModel());
 		return model;
 	}
 
-	protected Dataset<Row> selectColsFromBlocked(Dataset<Row> blocked) {
+	protected DataFrame selectColsFromBlocked(DataFrame blocked) {
 		return blocked.select(ColName.ID_COL, ColName.HASH_COL);
 	}
 
     public void execute() throws ZinggClientException {
         try {
 			// read input, filter, remove self joins
-			Dataset<Row> testData = getTestData();
-			testData = testData.repartition(args.getNumPartitions(), testData.col(ColName.ID_COL));
+			DataFrame testData = getTestData();
+			//testData = testData.repartition(args.getNumPartitions(), testData.col(ColName.ID_COL));
 			//testData = dropDuplicates(testData);
 			long count = testData.count();
 			LOG.info("Read " + count);
 			Analytics.track(Metric.DATA_COUNT, count, args.getCollectMetrics());
 
-			Dataset<Row> blocked = getBlocked(testData);
+			DataFrame blocked = getBlocked(testData);
 			LOG.info("Blocked ");
-			/*blocked = blocked.cache();
+			/*blocked = blocked.cacheResult();
 			blocked.withColumn("partition_id", functions.spark_partition_id())
 				.groupBy("partition_id").agg(functions.count("z_zid")).as("zid").orderBy("partition_id").toJavaRDD().saveAsTextFile("/tmp/zblockedParts");
 				*/
@@ -116,7 +115,7 @@ public class Matcher extends ZinggBase{
 				LOG.debug("Num distinct hashes " + blocked.select(ColName.HASH_COL).distinct().count());
 			}
 				//LOG.warn("Num distinct hashes " + blocked.agg(functions.approx_count_distinct(ColName.HASH_COL)).count());
-			Dataset<Row> blocks = getBlocks(selectColsFromBlocked(blocked), testData);
+			DataFrame blocks = getBlocks(selectColsFromBlocked(blocked), testData);
 			//blocks.explain();
 			//LOG.info("Blocks " + blocks.count());
 			if (LOG.isDebugEnabled()) {
@@ -124,19 +123,19 @@ public class Matcher extends ZinggBase{
 			}
 			//blocks.toJavaRDD().saveAsTextFile("/tmp/zblocks");
 			//check if all fields equal			
-			//Dataset<Row> allEqual = DSUtil.allFieldsEqual(blocks, args);
+			//DataFrame allEqual = DSUtil.allFieldsEqual(blocks, args);
 			//allEqual = allEqual.cache();
 			//send remaining to model 
 			Model model = getModel();
-			//blocks.cache().withColumn("partition_id", functions.spark_partition_id())
+			//blocks.cacheResult().withColumn("partition_id", functions.spark_partition_id())
 			//	.groupBy("partition_id").agg(functions.count("z_id")).ias("zid").orderBy("partition_id").;
 			/*
-			Dataset<Row> blocksRe = blocks.repartition(args.getNumPartitions());
+			DataFrame blocksRe = blocks.repartition(args.getNumPartitions());
 			blocksRe = blocksRe.cache();
 			blocksRe.withColumn("partition_id", functions.spark_partition_id())
 				.groupBy("partition_id").agg(functions.count("z_zid")).as("zid").orderBy("partition_id").toJavaRDD().saveAsTextFile("/tmp/zblocksPart");
 			*/
-			Dataset<Row> dupes = model.predict(blocks); //.exceptAll(allEqual));	
+			DataFrame dupes = model.predict(blocks); //.exceptAll(allEqual));	
 			//allEqual = massageAllEquals(allEqual);
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Found dupes " + dupes.count());	
@@ -145,7 +144,7 @@ public class Matcher extends ZinggBase{
 			
 			//allEqual = allEqual.cache();
 			//writeOutput(blocked, dupes.union(allEqual).cache());		
-			Dataset<Row> dupesActual = getDupesActualForGraph(dupes);
+			DataFrame dupesActual = getDupesActualForGraph(dupes);
 			//dupesActual.explain();
 			//dupesActual.toJavaRDD().saveAsTextFile("/tmp/zdupes");
 			
@@ -157,7 +156,7 @@ public class Matcher extends ZinggBase{
 		}
     }
 
-	public void writeOutput(Dataset<Row> blocked, Dataset<Row> dupesActual) {
+	public void writeOutput(DataFrame blocked, DataFrame dupesActual) {
 		try{
 		//input dupes are pairs
 		///pick ones according to the threshold by user
@@ -168,19 +167,19 @@ public class Matcher extends ZinggBase{
 			//-1 is initial suggestion, 1 is add, 0 is deletion, 2 is unsure
 			/*blocked = blocked.drop(ColName.HASH_COL);
 			blocked = blocked.drop(ColName.SOURCE_COL);
-			blocked = blocked.cache();
+			blocked = blocked.cacheResult();
 			*/
 			
-			dupesActual = dupesActual.cache();
-			Dataset<Row> graph = GraphUtil.buildGraph(blocked, dupesActual).cache();
+			dupesActual = dupesActual.cacheResult();
+			DataFrame graph = GraphUtil.buildGraph(blocked, dupesActual).cacheResult();
 			//graph.toJavaRDD().saveAsTextFile("/tmp/zgraph");
 			
 			//write score
-			Dataset<Row> score = getMinMaxScores(dupesActual, graph).cache();
+			DataFrame score = getMinMaxScores(dupesActual, graph).cacheResult();
 			//score.toJavaRDD().coalesce(1).saveAsTextFile("/tmp/zallscoresAvg");
-			graph = graph.repartition(args.getNumPartitions(), graph.col(ColName.ID_COL)).cache();
-			Dataset<Row> graphWithScores = DSUtil.joinZColFirst(
-				score, graph, ColName.ID_COL, false).cache();
+			//graph = graph.repartition(args.getNumPartitions(), graph.col(ColName.ID_COL)).cacheResult();
+			DataFrame graphWithScores = DSUtil.joinZColFirst(
+				score, graph, ColName.ID_COL, false).cacheResult();
 				//graphWithScores.toJavaRDD().saveAsTextFile("/tmp/zgraphWScores");
 			graphWithScores = graphWithScores.drop(ColName.HASH_COL);
 			graphWithScores = graphWithScores.drop(ColName.COL_PREFIX + ColName.ID_COL);
@@ -204,42 +203,42 @@ public class Matcher extends ZinggBase{
 		
 	}
 
-	protected Dataset<Row> getMinMaxScores(Dataset<Row> dupes, Dataset<Row> graph) {
+	protected DataFrame getMinMaxScores(DataFrame dupes, DataFrame graph) {
 		if (LOG.isDebugEnabled()) dupes.show(500);
 		
-		Dataset<Row> graph1 = graph.select(ColName.ID_COL, ColName.CLUSTER_COLUMN);
-		graph1 = graph1.repartition(args.getNumPartitions(),
-			graph1.col(ColName.CLUSTER_COLUMN));
-		Dataset<Row> dupesWithIds = dupes.select(ColName.ID_COL, ColName.COL_PREFIX + ColName.ID_COL);
+		DataFrame graph1 = graph.select(ColName.ID_COL, ColName.CLUSTER_COLUMN);
+		//graph1 = graph1.repartition(args.getNumPartitions(),
+			//graph1.col(ColName.CLUSTER_COLUMN));
+		DataFrame dupesWithIds = dupes.select(ColName.ID_COL, ColName.COL_PREFIX + ColName.ID_COL);
 		LOG.warn("Dupes with ids ");
 		if (LOG.isDebugEnabled()) dupesWithIds.show(500);
-		Dataset<Row> graphPairsFound = graph1.as("first").join(graph1.as("second"), ColName.CLUSTER_COLUMN)
-			.selectExpr("first.z_zid as z_zid", "second.z_zid as z_z_zid");
+		DataFrame graphPairsFound = graph1.join(graph1, ColName.CLUSTER_COLUMN);
+			//TODO-SNOW .select(Functions.col("l_...._z_zid").as("z_zid"), "r_z_zid as z_z_zid");
 		graphPairsFound = graphPairsFound.filter(graphPairsFound.col(ColName.ID_COL).gt(graphPairsFound.col(ColName.COL_PREFIX + ColName.ID_COL)));
 		
 		LOG.warn("graph pairs ");
 		if (LOG.isDebugEnabled()) graphPairsFound.show(500);
 		
-		Dataset<Row> graphPairsExtra = graphPairsFound.except(dupesWithIds);
-		Dataset<Row> graphPairsExtrawithDummyScore = graphPairsExtra.withColumn(ColName.SCORE_COL, functions.lit(0.0));
+		DataFrame graphPairsExtra = graphPairsFound.except(dupesWithIds);
+		DataFrame graphPairsExtrawithDummyScore = graphPairsExtra.withColumn(ColName.SCORE_COL, Functions.lit(0.0));
 		LOG.warn("graph pairs extra");
 		if (LOG.isDebugEnabled()) graphPairsExtra.show(500);
 		
 		//original
-		Dataset<Row> s1 = dupes.select(ColName.SCORE_COL, ColName.ID_COL);
-		Dataset<Row> s2 = dupes.select(ColName.SCORE_COL, ColName.COL_PREFIX + ColName.ID_COL);
+		DataFrame s1 = dupes.select(ColName.SCORE_COL, ColName.ID_COL);
+		DataFrame s2 = dupes.select(ColName.SCORE_COL, ColName.COL_PREFIX + ColName.ID_COL);
 
 		//add the graph discovered extra pairs
 		s1 = s1.union(graphPairsExtrawithDummyScore.select(ColName.SCORE_COL, ColName.ID_COL));
 		s2 = s2.union(graphPairsExtrawithDummyScore.select(ColName.SCORE_COL, ColName.COL_PREFIX + ColName.ID_COL));
 		List<Column> cols = new ArrayList<Column>();
 		
-		Dataset<Row> s1RightCols = s1.toDF(ColName.SCORE_COL, ColName.COL_PREFIX + ColName.ID_COL).cache();
-		Dataset<Row> allScores = s1RightCols.union(s2);
+		DataFrame s1RightCols = s1.toDF(ColName.SCORE_COL, ColName.COL_PREFIX + ColName.ID_COL).cacheResult();
+		DataFrame allScores = s1RightCols.union(s2);
 		//allScores.toJavaRDD().coalesce(1).saveAsTextFile("/tmp/zallscores");
 		/*WindowSpec window = Window.partitionBy(ColName.ID_COL).orderBy(ColName.SCORE_COL);
 		//WindowSpec window = Window.orderBy(ColName.CLUSTER_COLUMN);
-		Dataset<Row> ranked = allScores.withColumn("rank", functions.rank().over(window)).
+		DataFrame ranked = allScores.withColumn("rank", functions.rank().over(window)).
 			withColumn("minScore", functions.min(ColName.SCORE_COL).over(window)).
 			withColumn("maxScore", functions.max(ColName.SCORE_COL).over(window)).
 			where("rank == 1");
@@ -249,27 +248,27 @@ public class Matcher extends ZinggBase{
 		//graph = graph.withColumn(ColName.DENSE_COL, functions.dense_rank().over(window));
 		//graph = graph.withColumn("row_num", functions.row_number().over(window));
 		*/
-		allScores = allScores.repartition(args.getNumPartitions(), allScores.col(ColName.COL_PREFIX + ColName.ID_COL));
+		//allScores = allScores.repartition(args.getNumPartitions(), allScores.col(ColName.COL_PREFIX + ColName.ID_COL));
 		
 		return allScores.groupBy(allScores.col(ColName.COL_PREFIX + ColName.ID_COL)).agg(
-			functions.min(ColName.SCORE_COL).as(ColName.SCORE_MIN_COL),
-			functions.max(ColName.SCORE_COL).as(ColName.SCORE_MAX_COL));			
+			Functions.min(col(ColName.SCORE_COL)).as(ColName.SCORE_MIN_COL),
+			Functions.max(col(ColName.SCORE_COL)).as(ColName.SCORE_MAX_COL));			
 	}
 
-	protected Dataset<Row> getDupesActualForGraph(Dataset<Row> dupes) {
-		Dataset<Row> dupesActual = selectColsFromDupes(dupes);
+	protected DataFrame getDupesActualForGraph(DataFrame dupes) {
+		DataFrame dupesActual = selectColsFromDupes(dupes);
 		LOG.debug("dupes al");
-		if (LOG.isDebugEnabled()) dupes.show(false);
-		return dupes.filter(dupes.col(ColName.PREDICTION_COL).equalTo(ColValues.IS_MATCH_PREDICTION));
+		if (LOG.isDebugEnabled()) dupes.show();
+		return dupes.filter(dupes.col(ColName.PREDICTION_COL).in(ColValues.IS_MATCH_PREDICTION));
 	}
 
-	protected Dataset<Row> selectColsFromDupes(Dataset<Row> dupesActual) {
+	protected DataFrame selectColsFromDupes(DataFrame dupesActual) {
 		List<Column> cols = new ArrayList<Column>();
 		cols.add(dupesActual.col(ColName.ID_COL));
 		cols.add(dupesActual.col(ColName.COL_PREFIX + ColName.ID_COL));
 		cols.add(dupesActual.col(ColName.PREDICTION_COL));
 		cols.add(dupesActual.col(ColName.SCORE_COL));
-		Dataset<Row> dupesActual1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq()); //.cache();
+		DataFrame dupesActual1 = dupesActual.select(cols.toArray(Column[]::new)); //.cacheResult();
 		return dupesActual1;
 	}
 	

--- a/core/src/main/java/zingg/Matcher.java
+++ b/core/src/main/java/zingg/Matcher.java
@@ -22,7 +22,6 @@ import zingg.client.ZinggOptions;
 import zingg.util.Analytics;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
-import zingg.util.Metric;
 import zingg.client.util.Util;
 import zingg.util.BlockingTreeUtil;
 import zingg.util.DSUtil;
@@ -103,7 +102,7 @@ public class Matcher extends ZinggBase{
 			//testData = dropDuplicates(testData);
 			long count = testData.count();
 			LOG.info("Read " + count);
-			Analytics.track(Metric.DATA_COUNT, count, args.getCollectMetrics());
+			//Analytics.track(Metric.DATA_COUNT, count, args.getCollectMetrics());
 
 			DataFrame blocked = getBlocked(testData);
 			LOG.info("Blocked ");
@@ -194,7 +193,7 @@ public class Matcher extends ZinggBase{
 			}
 			graphWithScores = DSUtil.select(graphWithScores, columns);
 			*/
-			PipeUtil.write(graphWithScores, args, ctx, args.getOutput());
+			PipeUtil.write(graphWithScores, args, args.getOutput());
 		}
 		}
 		catch(Exception e) {

--- a/core/src/main/java/zingg/TrainMatcher.java
+++ b/core/src/main/java/zingg/TrainMatcher.java
@@ -5,11 +5,10 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import com.snowflake.snowpark_java.Column;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Functions;
 
 import scala.collection.JavaConverters;
 import zingg.block.Block;

--- a/core/src/main/java/zingg/Trainer.java
+++ b/core/src/main/java/zingg/Trainer.java
@@ -4,6 +4,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Functions;
 import com.snowflake.snowpark_java.Row;
 import zingg.block.Canopy;
 import zingg.block.Tree;
@@ -40,8 +41,8 @@ public class Trainer extends ZinggBase{
 			DataFrame tra = DSUtil.getTraining(snow, args);
 			tra = DSUtil.joinWithItself(tra, ColName.CLUSTER_COLUMN, true);
 			tra = tra.cacheResult();
-			positives = tra.filter(tra.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_MATCH));
-			negatives = tra.filter(tra.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_NOT_A_MATCH));
+			positives = tra.filter(tra.col(ColName.MATCH_FLAG_COL).equal_to(Functions.lit(ColValues.MATCH_TYPE_MATCH)));
+			negatives = tra.filter(tra.col(ColName.MATCH_FLAG_COL).equal_to(Functions.lit(ColValues.MATCH_TYPE_NOT_A_MATCH)));
 			LOG.warn("Training on positive pairs - " + positives.count());
 			LOG.warn("Training on negative pairs - " + negatives.count());
 				
@@ -57,8 +58,8 @@ public class Trainer extends ZinggBase{
 			Model model = ModelUtil.createModel(positives, negatives, new Model(this.featurers), snow);
 			model.save(args.getModel());
 			LOG.info("Learnt similarity rules and saved output at " + args.getZinggDir());
-			Analytics.track(Metric.TRAINING_MATCHES, Metric.approxCount(positives), args.getCollectMetrics());
-			Analytics.track(Metric.TRAINING_NONMATCHES, Metric.approxCount(negatives), args.getCollectMetrics());
+			//Analytics.track(Metric.TRAINING_MATCHES, Metric.approxCount(positives), args.getCollectMetrics());
+			//Analytics.track(Metric.TRAINING_NONMATCHES, Metric.approxCount(negatives), args.getCollectMetrics());
 			LOG.info("Finished Learning phase");			
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/core/src/main/java/zingg/Trainer.java
+++ b/core/src/main/java/zingg/Trainer.java
@@ -15,7 +15,6 @@ import zingg.client.ZinggOptions;
 import zingg.util.Analytics;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
-import zingg.util.Metric;
 
 import zingg.util.BlockingTreeUtil;
 import zingg.util.DSUtil;
@@ -52,7 +51,7 @@ public class Trainer extends ZinggBase{
 			if (blockingTree == null || blockingTree.getSubTrees() == null) {
 				LOG.warn("Seems like no indexing rules have been learnt");
 			}
-			BlockingTreeUtil.writeBlockingTree(snow, ctx, blockingTree, args);
+			BlockingTreeUtil.writeBlockingTree(snow, blockingTree, args);
 			LOG.info("Learnt indexing rules and saved output at " + args.getZinggDir());
 			// model
 			Model model = ModelUtil.createModel(positives, negatives, new Model(this.featurers), snow);

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -54,8 +54,8 @@ public class TrainingDataFinder extends ZinggBase{
 				if (trFile != null) {
 					DataFrame trPairs = DSUtil.joinWithItself(trFile, ColName.CLUSTER_COLUMN, true);
 						
-						posPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_MATCH));
-						negPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_NOT_A_MATCH));
+						posPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).equal_to(Functions.lit(ColValues.MATCH_TYPE_MATCH)));
+						negPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).equal_to(Functions.lit(ColValues.MATCH_TYPE_NOT_A_MATCH)));
 						posPairs = posPairs.drop(ColName.MATCH_FLAG_COL, 
 								ColName.COL_PREFIX + ColName.MATCH_FLAG_COL,
 								ColName.CLUSTER_COLUMN,
@@ -142,13 +142,13 @@ public class TrainingDataFinder extends ZinggBase{
 
 	public DataFrame getUncertain(DataFrame dupes) {
 		//take lowest positive score and highest negative score in the ones marked matches
-		DataFrame pos = dupes.filter(dupes.col(ColName.PREDICTION_COL).in(ColValues.IS_MATCH_PREDICTION));
+		DataFrame pos = dupes.filter(dupes.col(ColName.PREDICTION_COL).equal_to(Functions.lit(ColValues.IS_MATCH_PREDICTION)));
 		pos = pos.sort(col(ColName.SCORE_COL).asc()).cacheResult();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("num pos " + pos.count());	
 		}
 		pos = pos.limit(10);
-		DataFrame neg = dupes.filter(dupes.col(ColName.PREDICTION_COL).in(ColValues.IS_NOT_A_MATCH_PREDICTION));
+		DataFrame neg = dupes.filter(dupes.col(ColName.PREDICTION_COL).equal_to(Functions.lit(ColValues.IS_NOT_A_MATCH_PREDICTION)));
 		neg = neg.sort(col(ColName.SCORE_COL).desc()).cacheResult();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("num neg " + neg.count());

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -7,8 +7,8 @@ import com.snowflake.snowpark_java.Functions;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
-import org.apache.spark.storage.StorageLevel;
+// import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+// import org.apache.spark.storage.StorageLevel;
 
 import zingg.block.Block;
 import zingg.block.Canopy;
@@ -86,11 +86,11 @@ public class TrainingDataFinder extends ZinggBase{
 				DataFrame sample = data.sample(args.getLabelDataSampleSize()); //.repartition(args.getNumPartitions()).persist(StorageLevel.MEMORY_ONLY());
 				Tree<Canopy> tree = BlockingTreeUtil.createBlockingTree(sample, posPairs, 1, -1, args, hashFunctions);			
 				DataFrame blocked = sample.map(new Block.BlockFunction(tree), RowEncoder.apply(Block.appendHashCol(sample.schema())));
-				blocked = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)).cacheResults();
+				//blocked = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)).cacheResults();
 				DataFrame blocks = DSUtil.joinWithItself(blocked, ColName.HASH_COL, true);
 				blocks = blocks.cacheResult();	
 				//TODO HASH Partition
-				if (negPairs!= null) negPairs = negPairs.persist(StorageLevel.MEMORY_ONLY());
+				if (negPairs!= null) //negPairs = negPairs.persist(StorageLevel.MEMORY_ONLY());
 					//train classifier and predict the blocked values from classifier
 					//only if we have some user data
 					if (posPairs != null && negPairs !=null 
@@ -106,7 +106,7 @@ public class TrainingDataFinder extends ZinggBase{
 						}
 						LOG.info("Writing uncertain pairs");
 						
-						dupes = dupes.persist(StorageLevel.MEMORY_ONLY());
+						//dupes = dupes.persist(StorageLevel.MEMORY_ONLY());
 						DataFrame uncertain = getUncertain(dupes);
 										
 						writeUncertain(uncertain);													

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -1,18 +1,14 @@
 package zingg;
 
-import java.util.ArrayList;
-import java.util.List;
+import static com.snowflake.snowpark_java.Functions.col;
+
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Functions;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.storage.StorageLevel;
-
-import static org.apache.spark.sql.functions.asc;
-import static org.apache.spark.sql.functions.desc;
 
 import zingg.block.Block;
 import zingg.block.Canopy;
@@ -30,8 +26,6 @@ import zingg.util.DSUtil;
 import zingg.util.ModelUtil;
 import zingg.util.PipeUtil;
 
-
-import zingg.scala.TypeTags;
 import zingg.scala.DFUtil;
 
 public class TrainingDataFinder extends ZinggBase{
@@ -43,25 +37,25 @@ public class TrainingDataFinder extends ZinggBase{
         setZinggOptions(ZinggOptions.FIND_TRAINING_DATA);
     }
 
-	public Dataset<Row> getTraining() {
-		return DSUtil.getTraining(spark, args);
+	public DataFrame getTraining() {
+		return DSUtil.getTraining(snow, args);
 	}
 
     public void execute() throws ZinggClientException {
 			try{
-				Dataset<Row> data = PipeUtil.read(spark, true, true, args.getData());
+				DataFrame data = PipeUtil.read(snow, true, true, args.getData());
 				LOG.warn("Read input data " + data.count());
 				//create 20 pos pairs
 
-				Dataset<Row> posPairs = null;
-				Dataset<Row> negPairs = null;
-				Dataset<Row> trFile = getTraining();					
+				DataFrame posPairs = null;
+				DataFrame negPairs = null;
+				DataFrame trFile = getTraining();					
 				
 				if (trFile != null) {
-					Dataset<Row> trPairs = DSUtil.joinWithItself(trFile, ColName.CLUSTER_COLUMN, true);
+					DataFrame trPairs = DSUtil.joinWithItself(trFile, ColName.CLUSTER_COLUMN, true);
 						
-						posPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).equalTo(ColValues.MATCH_TYPE_MATCH));
-						negPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).equalTo(ColValues.MATCH_TYPE_NOT_A_MATCH));
+						posPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_MATCH));
+						negPairs = trPairs.filter(trPairs.col(ColName.MATCH_FLAG_COL).in(ColValues.MATCH_TYPE_NOT_A_MATCH));
 						posPairs = posPairs.drop(ColName.MATCH_FLAG_COL, 
 								ColName.COL_PREFIX + ColName.MATCH_FLAG_COL,
 								ColName.CLUSTER_COLUMN,
@@ -76,7 +70,7 @@ public class TrainingDataFinder extends ZinggBase{
 					
 					
 				if (posPairs == null || posPairs.count() <= 5) {
-					Dataset<Row> posSamples = getPositiveSamples(data);
+					DataFrame posSamples = getPositiveSamples(data);
 					//posSamples.printSchema();
 					if (posPairs != null) {
 						//posPairs.printSchema();
@@ -86,15 +80,15 @@ public class TrainingDataFinder extends ZinggBase{
 						posPairs = posSamples;
 					}
 				}
-				posPairs = posPairs.cache();
-				if (negPairs!= null) negPairs = negPairs.cache();
+				posPairs = posPairs.cacheResult();
+				if (negPairs!= null) negPairs = negPairs.cacheResult();
 				//create random samples for blocking
-				Dataset<Row> sample = data.sample(false, args.getLabelDataSampleSize()).repartition(args.getNumPartitions()).persist(StorageLevel.MEMORY_ONLY());
+				DataFrame sample = data.sample(args.getLabelDataSampleSize()); //.repartition(args.getNumPartitions()).persist(StorageLevel.MEMORY_ONLY());
 				Tree<Canopy> tree = BlockingTreeUtil.createBlockingTree(sample, posPairs, 1, -1, args, hashFunctions);			
-				Dataset<Row> blocked = sample.map(new Block.BlockFunction(tree), RowEncoder.apply(Block.appendHashCol(sample.schema())));
-				blocked = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)).cache();
-				Dataset<Row> blocks = DSUtil.joinWithItself(blocked, ColName.HASH_COL, true);
-				blocks = blocks.cache();	
+				DataFrame blocked = sample.map(new Block.BlockFunction(tree), RowEncoder.apply(Block.appendHashCol(sample.schema())));
+				blocked = blocked.repartition(args.getNumPartitions(), blocked.col(ColName.HASH_COL)).cacheResults();
+				DataFrame blocks = DSUtil.joinWithItself(blocked, ColName.HASH_COL, true);
+				blocks = blocks.cacheResult();	
 				//TODO HASH Partition
 				if (negPairs!= null) negPairs = negPairs.persist(StorageLevel.MEMORY_ONLY());
 					//train classifier and predict the blocked values from classifier
@@ -105,23 +99,23 @@ public class TrainingDataFinder extends ZinggBase{
 						if (LOG.isDebugEnabled()) {
 							LOG.debug("num blocks " + blocks.count());		
 						}
-						Model model = ModelUtil.createModel(posPairs, negPairs, new LabelModel(this.featurers), spark);
-						Dataset<Row> dupes = model.predict(blocks); 
+						Model model = ModelUtil.createModel(posPairs, negPairs, new LabelModel(this.featurers), snow);
+						DataFrame dupes = model.predict(blocks); 
 						if (LOG.isDebugEnabled()) {
 							LOG.debug("num dupes " + dupes.count());	
 						}
 						LOG.info("Writing uncertain pairs");
 						
 						dupes = dupes.persist(StorageLevel.MEMORY_ONLY());
-						Dataset<Row> uncertain = getUncertain(dupes);
+						DataFrame uncertain = getUncertain(dupes);
 										
 						writeUncertain(uncertain);													
 				}
 				else {
 					LOG.info("Writing uncertain pairs when either positive or negative samples not provided ");
-					Dataset<Row> posFiltered = blocks.sample(false,  20.0d/blocks.count());
-					posFiltered = posFiltered.withColumn(ColName.PREDICTION_COL, functions.lit(ColValues.IS_NOT_KNOWN_PREDICTION));
-					posFiltered = posFiltered.withColumn(ColName.SCORE_COL, functions.lit(ColValues.ZERO_SCORE));
+					DataFrame posFiltered = blocks.sample(20.0d/blocks.count());
+					posFiltered = posFiltered.withColumn(ColName.PREDICTION_COL, Functions.lit(ColValues.IS_NOT_KNOWN_PREDICTION));
+					posFiltered = posFiltered.withColumn(ColName.SCORE_COL, Functions.lit(ColValues.ZERO_SCORE));
 					writeUncertain(posFiltered);		
 				}			
 			}
@@ -131,12 +125,12 @@ public class TrainingDataFinder extends ZinggBase{
 			}	
     }
 
-	public void writeUncertain(Dataset<Row> dupesActual) {
+	public void writeUncertain(DataFrame dupesActual) {
 		//input dupes are pairs
-		dupesActual = DFUtil.addClusterRowNumber(dupesActual, spark);
+		dupesActual = DFUtil.addClusterRowNumber(dupesActual, snow);
 		dupesActual = Util.addUniqueCol(dupesActual, ColName.CLUSTER_COLUMN );		
-		Dataset<Row> dupes1 = DSUtil.alignDupes(dupesActual, args);
-		Dataset<Row> dupes2 = dupes1.orderBy(ColName.CLUSTER_COLUMN);
+		DataFrame dupes1 = DSUtil.alignDupes(dupesActual, args);
+		DataFrame dupes2 = dupes1.sort(col(ColName.CLUSTER_COLUMN));
 		LOG.debug("uncertain output schema is " + dupes2.schema());
 		PipeUtil.write(dupes2 , args, ctx, getUnmarkedLocation());
 		//PipeUtil.write(jdbc, massageForJdbc(dupes2.cache()) , args, ctx);
@@ -146,16 +140,16 @@ public class TrainingDataFinder extends ZinggBase{
 		return PipeUtil.getTrainingDataUnmarkedPipe(args);
 	}
 
-	public Dataset<Row> getUncertain(Dataset<Row> dupes) {
+	public DataFrame getUncertain(DataFrame dupes) {
 		//take lowest positive score and highest negative score in the ones marked matches
-		Dataset<Row> pos = dupes.filter(dupes.col(ColName.PREDICTION_COL).equalTo(ColValues.IS_MATCH_PREDICTION));
-		pos = pos.sort(asc(ColName.SCORE_COL)).cache();
+		DataFrame pos = dupes.filter(dupes.col(ColName.PREDICTION_COL).in(ColValues.IS_MATCH_PREDICTION));
+		pos = pos.sort(col(ColName.SCORE_COL).asc()).cacheResult();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("num pos " + pos.count());	
 		}
 		pos = pos.limit(10);
-		Dataset<Row> neg = dupes.filter(dupes.col(ColName.PREDICTION_COL).equalTo(ColValues.IS_NOT_A_MATCH_PREDICTION));
-		neg = neg.sort(desc(ColName.SCORE_COL)).cache();
+		DataFrame neg = dupes.filter(dupes.col(ColName.PREDICTION_COL).in(ColValues.IS_NOT_A_MATCH_PREDICTION));
+		neg = neg.sort(col(ColName.SCORE_COL).desc()).cacheResult();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("num neg " + neg.count());
 		}
@@ -163,20 +157,20 @@ public class TrainingDataFinder extends ZinggBase{
 		return pos.union(neg);
 	}
 
-	public Dataset<Row> getPositiveSamples(Dataset<Row> data) throws Exception {
+	public DataFrame getPositiveSamples(DataFrame data) throws Exception {
 		if (LOG.isDebugEnabled()) {
 			long count = data.count();
 			LOG.debug("Total count is " + count);
 			LOG.debug("Label data sample size is " + args.getLabelDataSampleSize());
 		}
-		Dataset<Row> posSample = data.sample(false, args.getLabelDataSampleSize());
+		DataFrame posSample = data.sample(args.getLabelDataSampleSize());
 		//select only those columns which are mentioned in the field definitions
 		posSample = DSUtil.getFieldDefColumnsDS(posSample, args, true);
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Sampled " + posSample.count());
 		}
-		posSample = posSample.cache();
-		Dataset<Row> posPairs = DSUtil.joinWithItself(posSample, ColName.ID_COL, false);
+		posSample = posSample.cacheResult();
+		DataFrame posPairs = DSUtil.joinWithItself(posSample, ColName.ID_COL, false);
 		
 		LOG.info("Created positive sample pairs ");
 		if (LOG.isDebugEnabled()) {

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -132,8 +132,7 @@ public class TrainingDataFinder extends ZinggBase{
 		DataFrame dupes1 = DSUtil.alignDupes(dupesActual, args);
 		DataFrame dupes2 = dupes1.sort(col(ColName.CLUSTER_COLUMN));
 		LOG.debug("uncertain output schema is " + dupes2.schema());
-		PipeUtil.write(dupes2 , args, ctx, getUnmarkedLocation());
-		//PipeUtil.write(jdbc, massageForJdbc(dupes2.cache()) , args, ctx);
+		PipeUtil.write(dupes2 , args, getUnmarkedLocation());
 	}
 
 	public Pipe getUnmarkedLocation() {

--- a/core/src/main/java/zingg/ZinggBase.java
+++ b/core/src/main/java/zingg/ZinggBase.java
@@ -8,10 +8,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.DataType;
-import com.snowflake.snowpark.Session;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.types.DataType;
 
 import zingg.client.Arguments;
 import zingg.client.FieldDefinition;
@@ -34,8 +32,7 @@ public abstract class ZinggBase implements Serializable, IZingg {
 
     protected Arguments args;
 	
-    protected JavaSparkContext ctx;
-	protected SparkSession spark;
+    //protected JavaSparkContext ctx;
     protected Session snow;
     protected static String name;
     protected ZinggOptions zinggOptions;
@@ -56,16 +53,16 @@ public abstract class ZinggBase implements Serializable, IZingg {
         try{
             snow = snowparkSession(args.getSnowflake());
 
-            spark = SparkSession
-                .builder()
-                .appName("Zingg"+args.getJobId())
-                .getOrCreate();
-            ctx = new JavaSparkContext(spark.sparkContext());
-            JavaSparkContext.jarOfClass(IZingg.class);
-            LOG.debug("Context " + ctx.toString());
+            // spark = Session
+            //     .builder()
+            //     .appName("Zingg"+args.getJobId())
+            //     .getOrCreate();
+            //ctx = new JavaSparkContext(snow.sparkContext());
+            // JavaSparkContext.jarOfClass(IZingg.class);
+            //LOG.debug("Context " + ctx.toString());
             initHashFns();
             loadFeatures();
-            ctx.setCheckpointDir("/tmp/checkpoint");	
+            //ctx.setCheckpointDir("/tmp/checkpoint");	
         }
         catch(Throwable e) {
             if (LOG.isDebugEnabled()) e.printStackTrace();
@@ -85,14 +82,14 @@ public abstract class ZinggBase implements Serializable, IZingg {
 
     @Override
     public void cleanup() throws ZinggClientException {
-        if (ctx != null) ctx.stop();
+        //if (ctx != null) ctx.stop();
         if (snow !=null) snow.close();
     }
 
     void initHashFns() throws ZinggClientException {
 		try {
 			//functions = Util.getFunctionList(this.functionFile);
-			hashFunctions = HashUtil.getHashFunctionList(this.hashFunctionFile, spark);
+			hashFunctions = HashUtil.getHashFunctionList(this.hashFunctionFile, snow);
 		} catch (Exception e) {
 			if (LOG.isDebugEnabled()) e.printStackTrace();
 			throw new ZinggClientException("Unable to initialize base functions");
@@ -123,8 +120,8 @@ public abstract class ZinggBase implements Serializable, IZingg {
 
     public void copyContext(ZinggBase b) {
             this.args = b.args;
-            this.ctx = b.ctx;
-            this.spark = b.spark;
+           // this.ctx = b.ctx;
+            this.snow = b.snow;
             this.featurers = b.featurers;
             this.hashFunctions = b.hashFunctions;
     }
@@ -165,20 +162,20 @@ public abstract class ZinggBase implements Serializable, IZingg {
         this.featurers = featurers;
     }
 
-    public JavaSparkContext getCtx() {
-        return this.ctx;
+    // public JavaSparkContext getCtx() {
+    //     return this.ctx;
+    // }
+
+    // public void setCtx(JavaSparkContext ctx) {
+    //     this.ctx = ctx;
+    // }
+
+    public Session getSnow() {
+        return this.snow;
     }
 
-    public void setCtx(JavaSparkContext ctx) {
-        this.ctx = ctx;
-    }
-
-    public SparkSession getSpark() {
-        return this.spark;
-    }
-
-    public void setSpark(SparkSession spark) {
-        this.spark = spark;
+    public void setSnow(Session snow) {
+        this.snow = snow;
     }
     public void setName(String name) {
         this.name = name;

--- a/core/src/main/java/zingg/block/Block.java
+++ b/core/src/main/java/zingg/block/Block.java
@@ -9,14 +9,13 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.api.java.function.MapFunction;
-import org.apache.spark.ml.util.SchemaUtils;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructType;
+// import org.apache.spark.api.java.function.MapFunction;
+// import org.apache.spark.ml.util.SchemaUtils;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.types.DataType;
+import com.snowflake.snowpark_java.types.DataTypes;
+import com.snowflake.snowpark_java.types.StructType;
 
 import zingg.client.FieldDefinition;
 import zingg.client.util.ListMap;
@@ -29,14 +28,14 @@ public class Block implements Serializable {
 
 	public static final Log LOG = LogFactory.getLog(Block.class);
 
-	protected Dataset<Row> dupes;
+	protected DataFrame dupes;
 	// Class[] types;
 	ListMap<DataType, HashFunction> functionsMap;
 	long maxSize;
-	Dataset<Row> training;
+	DataFrame training;
 	protected ListMap<HashFunction, String> childless;
 
-	protected Block(Dataset<Row> training, Dataset<Row> dupes) {
+	protected Block(DataFrame training, DataFrame dupes) {
 		this.training = training;
 		this.dupes = dupes;
 		childless = new ListMap<HashFunction, String>();
@@ -46,7 +45,7 @@ public class Block implements Serializable {
 		 */
 	}
 
-	public Block(Dataset<Row> training, Dataset<Row> dupes,
+	public Block(DataFrame training, DataFrame dupes,
 			ListMap<DataType, HashFunction> functionsMap, long maxSize) {
 		this(training, dupes);
 		this.functionsMap = functionsMap;
@@ -57,7 +56,7 @@ public class Block implements Serializable {
 	/**
 	 * @return the dupes
 	 */
-	public Dataset<Row> getDupes() {
+	public DataFrame getDupes() {
 		return dupes;
 	}
 
@@ -65,7 +64,7 @@ public class Block implements Serializable {
 	 * @param dupes
 	 *            the dupes to set
 	 */
-	public void setDupes(Dataset<Row> dupes) {
+	public void setDupes(DataFrame dupes) {
 		this.dupes = dupes;
 	}
 

--- a/core/src/main/java/zingg/block/Canopy.java
+++ b/core/src/main/java/zingg/block/Canopy.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.Row;
 
 import zingg.client.FieldDefinition;
 import zingg.client.util.ListMap;
@@ -39,7 +39,7 @@ public class Canopy implements Serializable {
 	}
 
 	public Canopy(List<Row> training, List<Row> dupeN) {
-		this.training = training; //.cache();
+		this.training = training; //.cacheResult();
 		this.dupeN = dupeN;
 	}
 
@@ -146,7 +146,7 @@ public class Canopy implements Serializable {
 	public List<Canopy> getCanopies() {
 		//long ts = System.currentTimeMillis();
 		/*
-		List<Row> newTraining = function.apply(training, context.fieldName, ColName.HASH_COL).cache();
+		List<Row> newTraining = function.apply(training, context.fieldName, ColName.HASH_COL).cacheResult();
 		LOG.debug("getCanopies0" + (System.currentTimeMillis() - ts));
 		List<Canopy> returnCanopies = new ArrayList<Canopy>();
 		//first find unique hashes
@@ -156,7 +156,7 @@ public class Canopy implements Serializable {
 		for (Row row : uniqueHashes) {
 			Object key = row.get(0);
 			List<Row> tupleList = newTraining.filter(newTraining.col(ColName.HASH_COL).equalTo(key))
-					.cache();
+					.cacheResult();
 			tupleList = tupleList.drop(ColName.HASH_COL);
 			Canopy can = new Canopy(tupleList, dupeRemaining);
 			//LOG.debug(" canopy size is " + tupleList.count() + " for  hash "

--- a/core/src/main/java/zingg/feature/FeatureFactory.java
+++ b/core/src/main/java/zingg/feature/FeatureFactory.java
@@ -6,8 +6,8 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.types.DataType;
+import com.snowflake.snowpark_java.types.DataTypes;
 public class FeatureFactory implements Serializable {
 
 	public static final Log LOG = LogFactory.getLog(FeatureFactory.class);

--- a/core/src/main/java/zingg/hash/First2CharsBox.java
+++ b/core/src/main/java/zingg/hash/First2CharsBox.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class First2CharsBox extends HashFunction implements UDF1<String, Integer>{
+public class First2CharsBox extends HashFunction implements JavaUDF1<String, Integer>{
 
 	public First2CharsBox() {
 		super("first2CharsBox", DataTypes.StringType, DataTypes.IntegerType, true);

--- a/core/src/main/java/zingg/hash/First3CharsBox.java
+++ b/core/src/main/java/zingg/hash/First3CharsBox.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class First3CharsBox extends HashFunction implements UDF1<String, Integer>{
+public class First3CharsBox extends HashFunction implements JavaUDF1<String, Integer>{
 
 	public First3CharsBox() {
 		super("first3CharsBox", DataTypes.StringType, DataTypes.IntegerType, true);
@@ -37,8 +37,8 @@ public class First3CharsBox extends HashFunction implements UDF1<String, Integer
 	 }
 	 
 	 @Override
-	 public Object apply(Row ds, String column) {
-		 return call((String) ds.getAs(column));
+	 public Object apply(Row ds, int column) {
+		 return call((String) ds.get(column));
 	}
 
 }

--- a/core/src/main/java/zingg/hash/FirstChars.java
+++ b/core/src/main/java/zingg/hash/FirstChars.java
@@ -2,14 +2,14 @@ package zingg.hash;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
 import zingg.block.Canopy;
 
 
-public class FirstChars extends HashFunction implements UDF1<String, String>{
+public class FirstChars extends HashFunction implements JavaUDF1<String, String>{
 	
 	public static final Log LOG = LogFactory.getLog(FirstChars.class);
 

--- a/core/src/main/java/zingg/hash/HashFunction.java
+++ b/core/src/main/java/zingg/hash/HashFunction.java
@@ -2,10 +2,10 @@ package zingg.hash;
 
 import java.io.Serializable;
 
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.types.DataType;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Functions;
+import com.snowflake.snowpark_java.types.DataType;
 
 public abstract class HashFunction implements Serializable{
 		/**
@@ -63,8 +63,8 @@ public abstract class HashFunction implements Serializable{
 		}
 
 		
-		public Dataset<Row> apply(Dataset<Row> ds, String column, String newColumn) {
-			return ds.withColumn(newColumn, functions.callUDF(this.name, ds.col(column)));
+		public DataFrame apply(DataFrame ds, String column, String newColumn) {
+			return ds.withColumn(newColumn, Functions.callUDF(this.name, ds.col(column)));
 		}
 		
 		public abstract Object apply(Row ds, String column);

--- a/core/src/main/java/zingg/hash/IdentityInteger.java
+++ b/core/src/main/java/zingg/hash/IdentityInteger.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class IdentityInteger extends HashFunction implements UDF1<Integer, Integer>{
+public class IdentityInteger extends HashFunction implements JavaUDF1<Integer, Integer>{
 	
 	public IdentityInteger() {
 		super("identityInteger", DataTypes.IntegerType, DataTypes.IntegerType);

--- a/core/src/main/java/zingg/hash/IdentityString.java
+++ b/core/src/main/java/zingg/hash/IdentityString.java
@@ -1,9 +1,9 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
-public class IdentityString extends HashFunction implements UDF1<String, String>{
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
+public class IdentityString extends HashFunction implements JavaUDF1<String, String>{
 	
 	public IdentityString() {
 		super("identityString", DataTypes.StringType, DataTypes.StringType);
@@ -16,7 +16,7 @@ public class IdentityString extends HashFunction implements UDF1<String, String>
 		 return field;
 	 }
 
-	public Object apply(Row ds, String column) {
-		 return call((String) ds.getAs(column));
+	public Object apply(Row ds, int column) {
+		 return call((String) ds.get(column));
 	}
 }

--- a/core/src/main/java/zingg/hash/IsNullOrEmpty.java
+++ b/core/src/main/java/zingg/hash/IsNullOrEmpty.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class IsNullOrEmpty extends HashFunction implements UDF1<String, Boolean>{
+public class IsNullOrEmpty extends HashFunction implements JavaUDF1<String, Boolean>{
 	
 	public IsNullOrEmpty() {
 		super("isNullOrEmpty", DataTypes.StringType, DataTypes.BooleanType);
@@ -15,7 +15,7 @@ public class IsNullOrEmpty extends HashFunction implements UDF1<String, Boolean>
 		 return (field == null || ((String ) field).trim().length() == 0);
 	 }
 
-	public Object apply(Row ds, String column) {
-		 return call((String) ds.getAs(column));
+	public Object apply(Row ds, int column) {
+		 return call((String) ds.get(column));
 	}
 }

--- a/core/src/main/java/zingg/hash/LastChars.java
+++ b/core/src/main/java/zingg/hash/LastChars.java
@@ -1,10 +1,12 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import java.util.Arrays;
 
-public class LastChars extends HashFunction implements UDF1<String, String>{
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
+
+public class LastChars extends HashFunction implements JavaUDF1<String, String>{
 	int numChars;
 	public LastChars(int endIndex) {
 		super("last" + endIndex + "Chars", DataTypes.StringType, DataTypes.StringType, true);
@@ -27,8 +29,8 @@ public class LastChars extends HashFunction implements UDF1<String, String>{
 				return r;
 			 }
 
-		 public Object apply(Row ds, String column) {
-			 return call((String) ds.getAs(column));
+		 public Object apply(Row ds, int column) {
+			 return call((String) ds.get(column));
 		 }
 
 }

--- a/core/src/main/java/zingg/hash/LastWord.java
+++ b/core/src/main/java/zingg/hash/LastWord.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class LastWord extends HashFunction implements UDF1<String, String>{
+public class LastWord extends HashFunction implements JavaUDF1<String, String>{
 	public LastWord() {
 		super("lastWord", DataTypes.StringType, DataTypes.StringType, true);
 	}

--- a/core/src/main/java/zingg/hash/Round.java
+++ b/core/src/main/java/zingg/hash/Round.java
@@ -1,10 +1,10 @@
 package zingg.hash;
 
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataTypes;
 
-public class Round extends HashFunction implements UDF1<Double, Long>{
+public class Round extends HashFunction implements JavaUDF1<Double, Long>{
 	
 	public Round() {
 		super("round", DataTypes.DoubleType, DataTypes.LongType);
@@ -17,7 +17,7 @@ public class Round extends HashFunction implements UDF1<Double, Long>{
 	 }
 
 	 @Override
-	 public Object apply(Row ds, String column) {
-		 return call((Double) ds.getAs(column));
+	 public Object apply(Row ds, int column) {
+		 return call((Double) ds.get(column));
 	}
 }

--- a/core/src/main/java/zingg/model/LabelModel.java
+++ b/core/src/main/java/zingg/model/LabelModel.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import org.apache.spark.ml.Pipeline;
 import org.apache.spark.ml.PipelineModel;
 import org.apache.spark.ml.PipelineStage;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
 
 import zingg.client.FieldDefinition;
 import zingg.feature.Feature;
@@ -21,11 +21,11 @@ public class LabelModel extends Model{
 	}
 
 	@Override	
-	public void fit(Dataset<Row> pos, Dataset<Row> neg) {
+	public void fit(DataFrame pos, DataFrame neg) {
 		//create features
 		Pipeline pipeline = new Pipeline();
 		pipeline.setStages(pipelineStage.toArray(new PipelineStage[pipelineStage.size()]));
-		PipelineModel pm = pipeline.fit(transform(pos.union(neg)).coalesce(1).cache());
+		PipelineModel pm = pipeline.fit(transform(pos.union(neg)).coalesce(1).cacheResult());
 		transformer = pm;	
 	}
 	

--- a/core/src/main/java/zingg/model/VectorValueExtractor.java
+++ b/core/src/main/java/zingg/model/VectorValueExtractor.java
@@ -2,18 +2,18 @@ package zingg.model;
 
 import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.util.Identifiable$;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.api.java.UDF2;
-import org.apache.spark.sql.types.DataTypes;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.Functions;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.udf.JavaUDF2;
+import com.snowflake.snowpark_java.types.DataTypes;
 
 import zingg.similarity.function.BaseTransformer;
 import zingg.client.util.ColName;
 
-public class VectorValueExtractor extends BaseTransformer implements UDF1<Vector, Double>{
+public class VectorValueExtractor extends BaseTransformer implements JavaUDF1<Vector, Double>{
 	
 	@Override
 	public Double call(Vector v) {
@@ -21,8 +21,8 @@ public class VectorValueExtractor extends BaseTransformer implements UDF1<Vector
 	}
 	
 	@Override
-	public void register(SparkSession spark) {
-    	spark.udf().register(uid, (UDF1) this, DataTypes.DoubleType);
+	public void register(Session spark) {
+    	spark.udf().register(uid, (JavaUDF1<Vector, Double>) this, DataTypes.DoubleType);
     }
 	
 	@Override
@@ -34,11 +34,11 @@ public class VectorValueExtractor extends BaseTransformer implements UDF1<Vector
    }
 	
 	@Override	
-	public Dataset<Row> transform(Dataset<?> ds){
+	public DataFrame transform(DataFrame ds){
 		LOG.debug("transforming dataset for " + uid);
 		transformSchema(ds.schema());
 		return ds.withColumn(getOutputCol(), 
-				functions.callUDF(this.uid, ds.col(getInputCol())));
+				Functions.callUDF(this.uid, ds.col(getInputCol())));
 	}
 
 }

--- a/core/src/main/java/zingg/similarity/function/BaseSimilarityFunction.java
+++ b/core/src/main/java/zingg/similarity/function/BaseSimilarityFunction.java
@@ -8,13 +8,13 @@ import org.apache.spark.ml.param.ParamMap;
 import org.apache.spark.ml.param.shared.HasInputCol;
 import org.apache.spark.ml.param.shared.HasOutputCol;
 import org.apache.spark.ml.util.Identifiable$;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.api.java.UDF2;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructType;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.Functions;
+import com.snowflake.snowpark_java.udf.JavaUDF2;
+import com.snowflake.snowpark_java.types.DataTypes;
+import com.snowflake.snowpark_java.types.StructType;
 
 import zingg.client.util.ColName;
 

--- a/core/src/main/java/zingg/similarity/function/SimFunction.java
+++ b/core/src/main/java/zingg/similarity/function/SimFunction.java
@@ -1,9 +1,8 @@
 package zingg.similarity.function;
 
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.api.java.UDF2;
+import com.snowflake.snowpark_java.udf.JavaUDF2;
 
-public interface SimFunction<T> extends UDF2<T,T, Double>{
+public interface SimFunction<T> extends JavaUDF2<T,T, Double>{
 	
 	
 	

--- a/core/src/main/java/zingg/sink/Sinker.java
+++ b/core/src/main/java/zingg/sink/Sinker.java
@@ -7,8 +7,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
 
 import zingg.client.Arguments;
 import zingg.client.pipe.Pipe;
@@ -69,7 +69,7 @@ public class Sinker {
 						return new TableOutput(0, System.currentTimeMillis(), t._2()._1, t._2()._2());
 					}
 				});
-				//Dataset<Row> rows = ((SparkContext) pretty.context()).createDataFrame(pretty, TableOutput.class);
+				//DataFrame rows = ((SparkContext) pretty.context()).createDataFrame(pretty, TableOutput.class);
 			*/	
 				
 		

--- a/core/src/main/java/zingg/util/Analytics.java
+++ b/core/src/main/java/zingg/util/Analytics.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.client.utils.URIBuilder;
+import net.snowflake.client.jdbc.internal.apache.http.client.utils.URIBuilder;
 
 public class Analytics {
 

--- a/core/src/main/java/zingg/util/BlockingTreeUtil.java
+++ b/core/src/main/java/zingg/util/BlockingTreeUtil.java
@@ -1,21 +1,18 @@
 package zingg.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.storage.StorageLevel;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.types.DataType;
+import com.snowflake.snowpark_java.types.DataTypes;
+import com.snowflake.snowpark_java.types.StructField;
+import com.snowflake.snowpark_java.types.StructType;
 
 import zingg.block.Block;
 import zingg.block.Canopy;
@@ -32,12 +29,12 @@ public class BlockingTreeUtil {
     public static final Log LOG = LogFactory.getLog(BlockingTreeUtil.class);
 	
 
-    public static Tree<Canopy> createBlockingTree(Dataset<Row> testData,  
-			Dataset<Row> positives, double sampleFraction, long blockSize,
+    public static Tree<Canopy> createBlockingTree(DataFrame testData,  
+			DataFrame positives, double sampleFraction, long blockSize,
             Arguments args,
             ListMap<DataType, HashFunction> hashFunctions) throws Exception {
-		Dataset<Row> sample = testData.sample(false, sampleFraction);
-		sample = sample.persist(StorageLevel.MEMORY_ONLY());
+		DataFrame sample = testData.sample(sampleFraction);
+		//sample = sample.persist(StorageLevel.MEMORY_ONLY());
 		long totalCount = sample.count();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Learning blocking rules for sample count " + totalCount  
@@ -46,9 +43,8 @@ public class BlockingTreeUtil {
 		if (blockSize == -1) blockSize = Heuristics.getMaxBlockSize(totalCount);
 		LOG.info("Learning indexing rules for block size " + blockSize);
        
-		positives = positives.coalesce(1); 
 		Block cblock = new Block(sample, positives, hashFunctions, blockSize);
-		Canopy root = new Canopy(sample.collectAsList(), positives.collectAsList());
+		Canopy root = new Canopy(Arrays.asList(sample.collect()), Arrays.asList(positives.collect()));
 
 		List<FieldDefinition> fd = new ArrayList<FieldDefinition> ();
 
@@ -69,26 +65,25 @@ public class BlockingTreeUtil {
 	}
 
 	
-	public static Tree<Canopy> createBlockingTreeFromSample(Dataset<Row> testData,  
-			Dataset<Row> positives, double sampleFraction, long blockSize, Arguments args, 
+	public static Tree<Canopy> createBlockingTreeFromSample(DataFrame testData,  
+			DataFrame positives, double sampleFraction, long blockSize, Arguments args, 
             ListMap<DataType, HashFunction> hashFunctions) throws Exception {
-		Dataset<Row> sample = testData.sample(false, sampleFraction); 
+		DataFrame sample = testData.sample(sampleFraction); 
 		return createBlockingTree(sample, positives, sampleFraction, blockSize, args, hashFunctions);
 	}
 	
-	public static void writeBlockingTree(SparkSession spark, JavaSparkContext ctx, Tree<Canopy> blockingTree, Arguments args) throws Exception {
+	public static void writeBlockingTree(Session snow, Tree<Canopy> blockingTree, Arguments args) throws Exception {
 		byte[] byteArray  = Util.convertObjectIntoByteArray(blockingTree);
-		StructType schema = DataTypes.createStructType(new StructField[] { DataTypes.createStructField("BlockingTree", DataTypes.BinaryType, false) });
+		StructType schema = StructType.create(new StructField[] { new StructField("BlockingTree", DataTypes.BinaryType, false) });
 		List<Object> objList = new ArrayList<>();
 		objList.add(byteArray);
-		JavaRDD<Row> rowRDD = ctx.parallelize(objList).map((Object row) -> RowFactory.create(row));
-		Dataset<Row> df = spark.sqlContext().createDataFrame(rowRDD, schema).toDF().coalesce(1);
-		PipeUtil.write(df, args, ctx, PipeUtil.getBlockingTreePipe(args));
+		DataFrame df = snow.createDataFrame(objList.toArray(Row[]::new), schema).toDF();
+		PipeUtil.write(df, args, PipeUtil.getBlockingTreePipe(args));
 	}
 
-	public static Tree<Canopy> readBlockingTree(SparkSession spark, Arguments args) throws Exception {
-		Dataset<Row> tree = PipeUtil.read(spark, false, args.getNumPartitions(), false, PipeUtil.getBlockingTreePipe(args));
-		byte [] byteArrayBack = (byte[]) tree.head().get(0);
+	public static Tree<Canopy> readBlockingTree(Session snow, Arguments args) throws Exception {
+		DataFrame tree = PipeUtil.read(snow, false, args.getNumPartitions(), false, PipeUtil.getBlockingTreePipe(args));
+		byte [] byteArrayBack = (byte[]) tree.first().get().get(0);
 		Tree<Canopy> blockingTree = null;
 		blockingTree =  (Tree<Canopy>) Util.revertObjectFromByteArray(byteArrayBack);
 		return blockingTree;

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -1,10 +1,19 @@
 package zingg.util;
 
-import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
+import static com.snowflake.snowpark_java.Functions.col;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.snowflake.snowpark_java.Column;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.Functions;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import scala.collection.JavaConverters;
 import zingg.client.Arguments;
@@ -13,13 +22,7 @@ import zingg.client.MatchType;
 import zingg.client.pipe.Pipe;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import zingg.client.util.Util;
 
 public class DSUtil {
 
@@ -32,12 +35,12 @@ public class DSUtil {
 		return cols;
 	}
 
-	public static Dataset<Row> getPrefixedColumnsDS(Dataset<Row> lines) {
-		return lines.toDF(getPrefixedColumns(lines.columns()));
+	public static DataFrame getPrefixedColumnsDS(DataFrame lines) {
+		return lines.toDF(getPrefixedColumns(lines.schema().names()));
 	}
 
-	public static Dataset<Row> join(Dataset<Row> lines, Dataset<Row> lines1, String joinColumn, boolean filter) {
-		Dataset<Row> pairs = lines.join(lines1, lines.col(joinColumn).equalTo(lines1.col(ColName.COL_PREFIX + joinColumn)));
+	public static DataFrame join(DataFrame lines, DataFrame lines1, String joinColumn, boolean filter) {
+		DataFrame pairs = lines.join(lines1, lines.col(joinColumn).in(lines1.col(ColName.COL_PREFIX + joinColumn)));
 		//in training, we only need that record matches only with lines bigger than itself
 		//in the case of normal as well as in the case of linking
 		if (LOG.isDebugEnabled()) {
@@ -49,8 +52,8 @@ public class DSUtil {
 		return pairs;
 	}
 
-	public static Dataset<Row> joinZColFirst(Dataset<Row> lines, Dataset<Row> lines1, String joinColumn, boolean filter) {
-		Dataset<Row> pairs = lines.join(lines1, lines.col(ColName.COL_PREFIX + joinColumn).equalTo(lines1.col(joinColumn)), "right");
+	public static DataFrame joinZColFirst(DataFrame lines, DataFrame lines1, String joinColumn, boolean filter) {
+		DataFrame pairs = lines.join(lines1, lines.col(ColName.COL_PREFIX + joinColumn).in(lines1.col(joinColumn)), "right");
 		//in training, we only need that record matches only with lines bigger than itself
 		//in the case of normal as well as in the case of linking
 		if (LOG.isDebugEnabled()) {
@@ -62,8 +65,8 @@ public class DSUtil {
 
 	/*
 
-	public static Dataset<Row> joinOnNamedColAndDropIt(Dataset<Row> lines, Dataset<Row> lines1, String joinColumn) {
-		Dataset<Row> pairs = lines.join(lines1, lines.col(joinColumn).equalTo(lines1.col(joinColumn).as(
+	public static DataFrame joinOnNamedColAndDropIt(DataFrame lines, DataFrame lines1, String joinColumn) {
+		DataFrame pairs = lines.join(lines1, lines.col(joinColumn).equalTo(lines1.col(joinColumn).as(
 			ColName.COL_PREFIX + joinColumn)));
 		pairs.show(false);
 		pairs = pairs.drop(ColName.COL_PREFIX + joinColumn);
@@ -77,22 +80,22 @@ public class DSUtil {
 	}
 	*/
 	
-    public static Dataset<Row> joinWithItself(Dataset<Row> lines, String joinColumn, boolean filter) throws Exception {
-		Dataset<Row> lines1 = getPrefixedColumnsDS(lines); 
+    public static DataFrame joinWithItself(DataFrame lines, String joinColumn, boolean filter) throws Exception {
+		DataFrame lines1 = getPrefixedColumnsDS(lines); 
 		return join(lines, lines1, joinColumn, filter);
 	}
 	
-	public static Dataset<Row> joinWithItselfSourceSensitive(Dataset<Row> lines, String joinColumn, Arguments args) throws Exception {
-		Dataset<Row> lines1 = getPrefixedColumnsDS(lines).cache();
+	public static DataFrame joinWithItselfSourceSensitive(DataFrame lines, String joinColumn, Arguments args) throws Exception {
+		DataFrame lines1 = getPrefixedColumnsDS(lines).cacheResult();
 		String[] sourceNames = args.getPipeNames();
-		lines = lines.filter(lines.col(ColName.SOURCE_COL).equalTo(sourceNames[0]));
-		lines1 = lines1.filter(lines1.col(ColName.COL_PREFIX + ColName.SOURCE_COL).notEqual(sourceNames[0]));
+		lines = lines.filter(lines.col(ColName.SOURCE_COL).in(sourceNames[0]));
+		lines1 = lines1.filter(lines1.col(ColName.COL_PREFIX + ColName.SOURCE_COL).in(sourceNames[0]));
 		return join(lines, lines1, joinColumn, false);
 	}
 
-	public static Dataset<Row> alignLinked(Dataset<Row> dupesActual, Arguments args) {
-		dupesActual = dupesActual.cache();
-		dupesActual = dupesActual.withColumnRenamed(ColName.ID_COL, ColName.CLUSTER_COLUMN);
+	public static DataFrame alignLinked(DataFrame dupesActual, Arguments args) {
+		dupesActual = dupesActual.cacheResult();
+		dupesActual = dupesActual.rename(ColName.CLUSTER_COLUMN, col(ColName.ID_COL));
 		List<Column> cols = new ArrayList<Column>();
 		cols.add(dupesActual.col(ColName.CLUSTER_COLUMN));
 		cols.add(dupesActual.col(ColName.SCORE_COL));
@@ -102,7 +105,7 @@ public class DSUtil {
 		}	
 		cols.add(dupesActual.col(ColName.SOURCE_COL));	
 
-		Dataset<Row> dupes1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
+		DataFrame dupes1 = dupesActual.select(cols.toArray(Column[]::new));
 		dupes1 = dupes1.dropDuplicates(ColName.CLUSTER_COLUMN, ColName.SOURCE_COL);
 	 	List<Column> cols1 = new ArrayList<Column>();
 		cols1.add(dupesActual.col(ColName.CLUSTER_COLUMN));
@@ -117,14 +120,14 @@ public class DSUtil {
 		}*/
 		
 		
-		Dataset<Row> dupes2 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols1.iterator()).asScala().toSeq());
-	 	dupes2 = dupes2.toDF(dupes1.columns()).cache();
+		DataFrame dupes2 = dupesActual.select(cols1.toArray(Column[]::new));
+	 	dupes2 = dupes2.toDF(dupes1.schema().names()).cacheResult();
 		dupes1 = dupes1.union(dupes2);
 		return dupes1;
 	}
 
-	public static Dataset<Row> alignDupes(Dataset<Row> dupesActual, Arguments args) {
-		dupesActual = dupesActual.cache();
+	public static DataFrame alignDupes(DataFrame dupesActual, Arguments args) {
+		dupesActual = dupesActual.cacheResult();
 		List<Column> cols = new ArrayList<Column>();
 		
 		cols.add(dupesActual.col(ColName.CLUSTER_COLUMN));
@@ -137,7 +140,7 @@ public class DSUtil {
 		}
 		cols.add(dupesActual.col(ColName.SOURCE_COL));
 		
-		Dataset<Row> dupes1 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
+		DataFrame dupes1 = dupesActual.select(cols.toArray(Column[]::new));
 	 	List<Column> cols1 = new ArrayList<Column>();
 		cols1.add(dupesActual.col(ColName.CLUSTER_COLUMN));
 		cols1.add(dupesActual.col(ColName.COL_PREFIX + ColName.ID_COL)); 
@@ -154,19 +157,19 @@ public class DSUtil {
 		}*/
 		
 		
-		Dataset<Row> dupes2 = dupesActual.select(JavaConverters.asScalaIteratorConverter(cols1.iterator()).asScala().toSeq());
-	 	dupes2 = dupes2.toDF(dupes1.columns()).cache();
+		DataFrame dupes2 = dupesActual.select(cols1.toArray(Column[]::new));
+	 	dupes2 = dupes2.toDF(dupes1.schema().names()).cacheResult();
 		dupes1 = dupes1.union(dupes2);
-		dupes1 = dupes1.withColumn(ColName.MATCH_FLAG_COL, functions.lit(ColValues.MATCH_TYPE_UNKNOWN));
+		dupes1 = dupes1.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(ColValues.MATCH_TYPE_UNKNOWN));
 		return dupes1;
 	}
 
-	public static Dataset<Row> allFieldsEqual(Dataset<Row> a, Arguments args) {
+	public static DataFrame allFieldsEqual(DataFrame a, Arguments args) {
 		for (FieldDefinition def : args.getFieldDefinition()) {
 			if (! (def.getMatchType() == null || def.getMatchType().equals(MatchType.DONT_USE))) {
 				//columns.add(def.getFieldName());
 				String field = def.getFieldName();
-				 a= a.filter(a.col(field).equalTo(
+				 a= a.filter(a.col(field).in(
 					 a.col(ColName.COL_PREFIX + field)));		
 			}
 		}
@@ -175,7 +178,7 @@ public class DSUtil {
 		
 	}
 
-	public static List<Column> getFieldDefColumns (Dataset<Row> ds, Arguments args, boolean includeZid) {
+	public static List<Column> getFieldDefColumns (DataFrame ds, Arguments args, boolean includeZid) {
 		List<Column> cols = new ArrayList<Column>();
 		if (includeZid) {
 			cols.add(ds.col(ColName.ID_COL));						
@@ -188,15 +191,15 @@ public class DSUtil {
 
 	}
 
-	public static Dataset<Row> getFieldDefColumnsDS(Dataset<Row> ds, Arguments args, boolean includeZid) {
+	public static DataFrame getFieldDefColumnsDS(DataFrame ds, Arguments args, boolean includeZid) {
 		return select(ds, getFieldDefColumns(ds, args, includeZid));
 	}
 
-	public static Dataset<Row> select(Dataset<Row> ds, List<Column> cols) {
-		return ds.select(JavaConverters.asScalaIteratorConverter(cols.iterator()).asScala().toSeq());
+	public static DataFrame select(DataFrame ds, List<Column> cols) {
+		return ds.select(cols.stream().toArray(Column[]::new));
 	}
 
-	public static Dataset<Row> dropDuplicates(Dataset<Row> a, Arguments args) {
+	public static DataFrame dropDuplicates(DataFrame a, Arguments args) {
 		LOG.info("duplicates before " + a.count());
 		List<String> cols = new ArrayList<String>();
 		for (FieldDefinition def : args.getFieldDefinition()) {
@@ -206,36 +209,36 @@ public class DSUtil {
 				cols.add(field);	
 			}
 		}
-		a = a.dropDuplicates(cols.stream().toArray(String[]::new));
+		a = a.dropDuplicates(cols.toArray(String[]::new));
 		LOG.info("duplicates after " + a.count());
 		return a;			
 	}	
 
-	public static Dataset<Row> getTraining(SparkSession spark, Arguments args) {
-		return getTraining(spark, args, PipeUtil.getTrainingDataMarkedPipe(args)); 			
+	public static DataFrame getTraining(Session snow, Arguments args) {
+		return getTraining(snow, args, PipeUtil.getTrainingDataMarkedPipe(args)); 			
 	}
 
-	public static Dataset<Row> getTrainingJdbc(SparkSession spark, Arguments args) {
-		return getTraining(spark, args, args.getOutput()[0]);
+	public static DataFrame getTrainingJdbc(Session snow, Arguments args) {
+		return getTraining(snow, args, args.getOutput()[0]);
 	}
 
-	private static Dataset<Row> getTraining(SparkSession spark, Arguments args, Pipe p) {
-		Dataset<Row> trFile = null;
+	private static DataFrame getTraining(Session snow, Arguments args, Pipe p) {
+		DataFrame trFile = null;
 		try{
-			trFile = PipeUtil.read(spark, 
+			trFile = PipeUtil.read(snow, 
 					false, false, p); 
 			LOG.warn("Read marked training samples ");
-			trFile = trFile.drop(ColName.PREDICTION_COL);
-			trFile = trFile.drop(ColName.SCORE_COL);				
+			trFile = trFile.drop(Util.toColsArray(ColName.PREDICTION_COL));
+			trFile = trFile.drop(Util.toColsArray(ColName.SCORE_COL));
 		}
 		catch (Exception e) {
 			LOG.warn("No preexisting marked training samples");
 		}
 		if (args.getTrainingSamples() != null) {
-			Dataset<Row> trSamples = PipeUtil.read(spark, 
+			DataFrame trSamples = PipeUtil.read(snow, 
 				true, false, args.getTrainingSamples()); 
 			LOG.warn("Read all training samples ");
-			trFile = (trFile == null) ? trSamples : trFile.unionByName(trSamples, true);
+			trFile = (trFile == null) ? trSamples : trFile.unionByName(trSamples);
 		} 
 		else {
 			LOG.warn("No configured training samples");

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -40,7 +40,7 @@ public class DSUtil {
 	}
 
 	public static DataFrame join(DataFrame lines, DataFrame lines1, String joinColumn, boolean filter) {
-		DataFrame pairs = lines.join(lines1, lines.col(joinColumn).in(lines1.col(ColName.COL_PREFIX + joinColumn)));
+		DataFrame pairs = lines.join(lines1, lines.col(joinColumn).equal_to(lines1.col(ColName.COL_PREFIX + joinColumn)));
 		//in training, we only need that record matches only with lines bigger than itself
 		//in the case of normal as well as in the case of linking
 		if (LOG.isDebugEnabled()) {
@@ -53,7 +53,7 @@ public class DSUtil {
 	}
 
 	public static DataFrame joinZColFirst(DataFrame lines, DataFrame lines1, String joinColumn, boolean filter) {
-		DataFrame pairs = lines.join(lines1, lines.col(ColName.COL_PREFIX + joinColumn).in(lines1.col(joinColumn)), "right");
+		DataFrame pairs = lines.join(lines1, lines.col(ColName.COL_PREFIX + joinColumn).equal_to(lines1.col(joinColumn)), "right");
 		//in training, we only need that record matches only with lines bigger than itself
 		//in the case of normal as well as in the case of linking
 		if (LOG.isDebugEnabled()) {
@@ -88,8 +88,8 @@ public class DSUtil {
 	public static DataFrame joinWithItselfSourceSensitive(DataFrame lines, String joinColumn, Arguments args) throws Exception {
 		DataFrame lines1 = getPrefixedColumnsDS(lines).cacheResult();
 		String[] sourceNames = args.getPipeNames();
-		lines = lines.filter(lines.col(ColName.SOURCE_COL).in(sourceNames[0]));
-		lines1 = lines1.filter(lines1.col(ColName.COL_PREFIX + ColName.SOURCE_COL).in(sourceNames[0]));
+		lines = lines.filter(lines.col(ColName.SOURCE_COL).equal_to(Functions.lit(sourceNames[0])));
+		lines1 = lines1.filter(lines1.col(ColName.COL_PREFIX + ColName.SOURCE_COL).equal_to(Functions.lit(sourceNames[0])));
 		return join(lines, lines1, joinColumn, false);
 	}
 
@@ -169,7 +169,7 @@ public class DSUtil {
 			if (! (def.getMatchType() == null || def.getMatchType().equals(MatchType.DONT_USE))) {
 				//columns.add(def.getFieldName());
 				String field = def.getFieldName();
-				 a= a.filter(a.col(field).in(
+				 a= a.filter(a.col(field).equal_to(
 					 a.col(ColName.COL_PREFIX + field)));		
 			}
 		}

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -228,8 +228,8 @@ public class DSUtil {
 			trFile = PipeUtil.read(snow, 
 					false, false, p); 
 			LOG.warn("Read marked training samples ");
-			trFile = trFile.drop(Util.toColsArray(ColName.PREDICTION_COL));
-			trFile = trFile.drop(Util.toColsArray(ColName.SCORE_COL));
+			trFile = trFile.drop(ColName.PREDICTION_COL);
+			trFile = trFile.drop(ColName.SCORE_COL);
 		}
 		catch (Exception e) {
 			LOG.warn("No preexisting marked training samples");
@@ -252,5 +252,9 @@ public class DSUtil {
 				.stream()
 				.filter(f -> !(f.getMatchType() == null || f.getMatchType().equals(MatchType.DONT_USE)))
 				.collect(Collectors.toList());
+	}
+
+	public static int getIndex(DataFrame df, String colName) {
+		return Arrays.asList(df.schema().names()).indexOf(colName);
 	}
 }

--- a/core/src/main/java/zingg/util/FileUtil.java
+++ b/core/src/main/java/zingg/util/FileUtil.java
@@ -1,4 +1,4 @@
-package zingg.client.util;
+package zingg.util;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -20,20 +20,12 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.spark.SparkContext;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.api.java.UDF1;
-import org.apache.spark.sql.types.DataType;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
+import com.snowflake.snowpark_java.Session;
+import com.snowflake.snowpark_java.Functions;
+import com.snowflake.snowpark_java.udf.JavaUDF1;
+import com.snowflake.snowpark_java.types.DataType;
 
 import zingg.client.util.ListMap;
 
@@ -41,40 +33,12 @@ public class FileUtil implements Serializable {
 
 	public static final Log LOG = LogFactory.getLog(FileUtil.class);
 	
-		
-	public static String getNextLabelPath(String path) throws IOException {
-		Configuration conf = new Configuration();
-		FileSystem fs = FileSystem.get(conf);
-		Path fsPath = new Path(path);
-		String pathPrefix = "";
-		if (!fs.exists(fsPath)) {
-			pathPrefix += "0";
-		}
-		else {
-			FileStatus[] fileStatus = fs.listStatus(fsPath);
-			pathPrefix += fileStatus.length;
-		}
-		return pathPrefix;
-		
-	}
-	
-	public static String getCurrentLabelPath(String path) throws IOException {
-		Configuration conf = new Configuration();
-		FileSystem fs = FileSystem.get(conf);
-		Path fsPath = new Path(path);
-		int pathPrefix = 0;
-		FileStatus[] fileStatus = fs.listStatus(fsPath);
-		pathPrefix = fileStatus.length -1;
-		return new Integer(pathPrefix).toString();
-		
-	}
-	
-	public static Dataset<Row> addUniqueCol(Dataset<Row> dupesActual, String colName) {
+	public static DataFrame addUniqueCol(DataFrame dupesActual, String colName) {
 		String append = System.currentTimeMillis() + ":";
 		dupesActual = dupesActual.withColumn(colName + "temp", 
-				functions.lit(append));
+				Functions.lit(append));
 		dupesActual = dupesActual.withColumn(colName,
-				functions.concat(dupesActual.col(colName + "temp"),
+				Functions.concat(dupesActual.col(colName + "temp"),
 						dupesActual.col(colName)));
 		dupesActual = dupesActual.drop(dupesActual.col(colName + "temp"));
 		return dupesActual;

--- a/core/src/main/java/zingg/util/HashUtil.java
+++ b/core/src/main/java/zingg/util/HashUtil.java
@@ -38,7 +38,7 @@ public class HashUtil {
 				});
 		for (HashFnFromConf scriptArg : scriptArgs) {
 			HashFunction fn = HashFunctionRegistry.getFunction(scriptArg.getName());
-			snow.udf().registerPermanent(fn.getName(), (JavaUDF1<Vector, Double>) fn, fn.getDataType(), fn.getReturnType(), "stageLocation");
+			snow.udf().registerPermanent(fn.getName(), (JavaUDF1) fn, fn.getDataType(), fn.getReturnType(), "stageLocation");
 			functions.add(fn.getDataType(), fn);
 		}
 		return functions;

--- a/core/src/main/java/zingg/util/Metric.java
+++ b/core/src/main/java/zingg/util/Metric.java
@@ -16,7 +16,7 @@ public class Metric {
     public static final long timeout = 1200L;
     public static final double confidence = 0.95; // default value
 
-    public static double approxCount(DataFrame data) {
-        return data.async().count().getResult((int)timeout/1000);
-    }
+    // public static double approxCount(DataFrame data) {
+    //     return data.async().count().getResult((int)timeout/1000);
+    // }
 }

--- a/core/src/main/java/zingg/util/Metric.java
+++ b/core/src/main/java/zingg/util/Metric.java
@@ -1,7 +1,7 @@
 package zingg.util;
 
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
 
 public class Metric {
     public static final String DATA_FORMAT = "dataFormat";
@@ -16,7 +16,7 @@ public class Metric {
     public static final long timeout = 1200L;
     public static final double confidence = 0.95; // default value
 
-    public static double approxCount(Dataset<Row> data) {
-        return data.rdd().countApprox(timeout, confidence).initialValue().mean();
+    public static double approxCount(DataFrame data) {
+        return data.async().count().getResult((int)timeout/1000);
     }
 }

--- a/core/src/main/java/zingg/util/ModelUtil.java
+++ b/core/src/main/java/zingg/util/ModelUtil.java
@@ -2,13 +2,10 @@ package zingg.util;
 
 import com.snowflake.snowpark_java.Functions;
 import com.snowflake.snowpark_java.DataFrame;
-import com.snowflake.snowpark_java.Row;
-import org.apache.spark.storage.StorageLevel;
 
 import zingg.client.ZinggClientException;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
-import zingg.client.util.Util;
 import zingg.model.Model;
 
 import org.apache.commons.logging.Log;
@@ -24,10 +21,10 @@ public class ModelUtil {
         DataFrame negatives, Model model, Session snow) throws Exception, ZinggClientException {
         LOG.info("Learning similarity rules");
         DataFrame posLabeledPointsWithLabel = positives.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(ColValues.MATCH_TYPE_MATCH));
-        posLabeledPointsWithLabel = posLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
+        //posLabeledPointsWithLabel = posLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
         posLabeledPointsWithLabel = posLabeledPointsWithLabel.drop(ColName.PREDICTION_COL);
         DataFrame negLabeledPointsWithLabel = negatives.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(ColValues.MATCH_TYPE_NOT_A_MATCH));
-        negLabeledPointsWithLabel = negLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
+        //negLabeledPointsWithLabel = negLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
         negLabeledPointsWithLabel = negLabeledPointsWithLabel.drop(ColName.PREDICTION_COL);
         if (LOG.isDebugEnabled()) {
             LOG.debug(" +,-,Total labeled data "

--- a/core/src/main/java/zingg/util/ModelUtil.java
+++ b/core/src/main/java/zingg/util/ModelUtil.java
@@ -1,31 +1,32 @@
 package zingg.util;
 
-import org.apache.spark.sql.functions;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.Functions;
+import com.snowflake.snowpark_java.DataFrame;
+import com.snowflake.snowpark_java.Row;
 import org.apache.spark.storage.StorageLevel;
 
 import zingg.client.ZinggClientException;
 import zingg.client.util.ColName;
 import zingg.client.util.ColValues;
+import zingg.client.util.Util;
 import zingg.model.Model;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.apache.spark.sql.SparkSession;
+import com.snowflake.snowpark_java.Session;
 
 public class ModelUtil {
 
     public static final Log LOG = LogFactory.getLog(ModelUtil.class);
 
-	public static Model createModel(Dataset<Row> positives,
-        Dataset<Row> negatives, Model model, SparkSession spark) throws Exception, ZinggClientException {
+	public static Model createModel(DataFrame positives,
+        DataFrame negatives, Model model, Session snow) throws Exception, ZinggClientException {
         LOG.info("Learning similarity rules");
-        Dataset<Row> posLabeledPointsWithLabel = positives.withColumn(ColName.MATCH_FLAG_COL, functions.lit(ColValues.MATCH_TYPE_MATCH));
+        DataFrame posLabeledPointsWithLabel = positives.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(ColValues.MATCH_TYPE_MATCH));
         posLabeledPointsWithLabel = posLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
         posLabeledPointsWithLabel = posLabeledPointsWithLabel.drop(ColName.PREDICTION_COL);
-        Dataset<Row> negLabeledPointsWithLabel = negatives.withColumn(ColName.MATCH_FLAG_COL, functions.lit(ColValues.MATCH_TYPE_NOT_A_MATCH));
+        DataFrame negLabeledPointsWithLabel = negatives.withColumn(ColName.MATCH_FLAG_COL, Functions.lit(ColValues.MATCH_TYPE_NOT_A_MATCH));
         negLabeledPointsWithLabel = negLabeledPointsWithLabel.persist(StorageLevel.MEMORY_ONLY());
         negLabeledPointsWithLabel = negLabeledPointsWithLabel.drop(ColName.PREDICTION_COL);
         if (LOG.isDebugEnabled()) {
@@ -33,7 +34,7 @@ public class ModelUtil {
                     + posLabeledPointsWithLabel.count() + ", "
                     + negLabeledPointsWithLabel.count());
         }
-        model.register(spark);
+        model.register(snow);
         model.fit(posLabeledPointsWithLabel, negLabeledPointsWithLabel);
         return model;
     }

--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -32,6 +32,7 @@ import zingg.client.pipe.ElasticPipe;
 import zingg.client.pipe.FilePipe;
 import zingg.client.pipe.Format;
 import zingg.client.pipe.Pipe;
+import zingg.client.pipe.SnowPipe;
 import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -199,7 +200,7 @@ public class PipeUtil {
 			else {
 				writer.mode("Append");
 			}
- 			writer.saveAsTable(p.get(FilePipe.TABLENAME));			
+ 			writer.saveAsTable(p.get(SnowPipe.TABLENAME));			
 		}
 	}
 

--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -36,16 +36,7 @@ import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
-//import com.datastax.driver.core.ProtocolVersion;
-//import com.datastax.driver.core.ResultSet;
-//import com.datastax.driver.core.Session;
-//import com.datastax.spark.connector.DataFrameFunctions;
-
 import zingg.scala.DFUtil;
-
-//import com.datastax.spark.connector.cql.*;
-//import org.elasticsearch.spark.sql.api.java.JavaEsSparkSQL;
-//import zingg.scala.DFUtil;
 
 public class PipeUtil {
 
@@ -53,16 +44,13 @@ public class PipeUtil {
 
 	private static DataFrameReader getReader(Session snow, Pipe p) {
 		DataFrameReader reader = snow.read();
-
 		LOG.warn("Reading input " + p.getFormat().type());
-		reader = reader.format(p.getFormat().type());
 		if (p.getSchema() != null) {
 			reader = reader.schema(p.getSchema());
 		}
 		for (String key : p.getProps().keySet()) {
 			reader = reader.option(key, p.get(key));
 		}
-		reader = reader.option("mode", "PERMISSIVE");
 		return reader;
 	}
 
@@ -70,13 +58,35 @@ public class PipeUtil {
 		DataFrame input = null;
 		LOG.warn("Reading " + p);
 		if (p.getProps().containsKey(FilePipe.LOCATION)) {
-			input = reader.load(p.get(FilePipe.LOCATION));
+			input = load(reader, p);
 		}
 		else {
-			input = reader.load();
+			LOG.warn("Given Location is not found: " + p.get(FilePipe.LOCATION));
+			return null;
 		}
 		if (addSource) {
-			input = input.withColumn(ColName.SOURCE_COL, functions.lit(p.getName()));			
+			input = input.withColumn(ColName.SOURCE_COL, Functions.lit(p.getName()));			
+		}
+		return input;
+	}
+
+	private static DataFrame load(DataFrameReader reader, Pipe p) {
+		DataFrame input = null;
+		try {
+			switch (p.getFormat()) {
+				case CSV:
+					input = reader.csv(p.get(p.get(FilePipe.LOCATION)));
+				case JSON:
+					input = reader.json(p.get(p.get(FilePipe.LOCATION)));
+				case AVRO:
+					input = reader.avro(p.get(p.get(FilePipe.LOCATION)));
+				case PARQUET:
+					input = reader.parquet(p.get(p.get(FilePipe.LOCATION)));
+				default:
+					break;
+			}
+		} catch (Exception e) {
+			LOG.warn("given format not found, cannot read the file: " + p.get(FilePipe.LOCATION));
 		}
 		return input;
 	}
@@ -89,7 +99,7 @@ public class PipeUtil {
 	public static DataFrame joinTrainingSetstoGetLabels(DataFrame jdbc, 
 		DataFrame file)  {
 		file = file.drop(ColName.MATCH_FLAG_COL);
-		file.printSchema();
+		LOG.warn("Schema: " + file.schema().toString());
 		file.show();
 		jdbc = jdbc.select(jdbc.col(ColName.ID_COL), jdbc.col(ColName.SOURCE_COL),jdbc.col(ColName.MATCH_FLAG_COL),
 			jdbc.col(ColName.CLUSTER_COLUMN));
@@ -100,7 +110,7 @@ public class PipeUtil {
 		jdbc = jdbc.toDF(cols).cacheResult();
 
 		jdbc = jdbc.rename(ColName.MATCH_FLAG_COL, col(ColName.COL_PREFIX + ColName.MATCH_FLAG_COL));
-		jdbc.printSchema();
+		LOG.warn("Schema: " + jdbc.schema().toString());
 		jdbc.show();
 		LOG.warn("Building labels ");
 		DataFrame pairs = file.join(jdbc, file.col(ColName.ID_COL).equal_to(
@@ -156,8 +166,8 @@ public class PipeUtil {
 
 	public static DataFrame sample(Session snow, Pipe p) {
 		DataFrameReader reader = getReader(snow, p);
-		reader.option("inferSchema", true);
-		reader.option("mode", "DROPMALFORMED");
+		//reader.option("inferSchema", true);
+		//reader.option("mode", "DROPMALFORMED");
 		LOG.info("reader is ready to sample with inferring " + p.get(FilePipe.LOCATION));
 		LOG.warn("Reading input of type " + p.getFormat().type());
 		DataFrame input = read(reader, p, false);
@@ -177,112 +187,28 @@ public class PipeUtil {
 		return rows;
 	}
 
-	public static void write(DataFrame toWriteOrig, Arguments args, JavaSparkContext ctx, Pipe... pipes) {
-			for (Pipe p: pipes) {
+	public static void write(DataFrame toWriteOrig, Arguments args, Pipe... pipes) {
+		for (Pipe p: pipes) {
 			DataFrame toWrite = toWriteOrig;
 			DataFrameWriter writer = toWrite.write();
-		
+
 			LOG.warn("Writing output " + p);
-			
 			if (p.getMode() != null) {
 				writer.mode(p.getMode());
 			}
 			else {
 				writer.mode("Append");
 			}
-			if (p.getFormat().equals(Format.ELASTIC)) {
-				ctx.getConf().set(ElasticPipe.NODE, p.getProps().get(ElasticPipe.NODE));
-				ctx.getConf().set(ElasticPipe.PORT, p.getProps().get(ElasticPipe.PORT));
-				ctx.getConf().set(ElasticPipe.ID, ColName.ID_COL);
-				ctx.getConf().set(ElasticPipe.RESOURCE, p.getName());
-			}
-			writer = writer.format(p.getFormat().type());
-			
-			for (String key: p.getProps().keySet()) {
-				writer = writer.option(key, p.get(key));
-			}
-			if (p.getFormat() == Format.CASSANDRA) {
-				/*
-				ctx.getConf().set(CassandraPipe.HOST, p.getProps().get(CassandraPipe.HOST));
-				toWrite.sparkSession().conf().set(CassandraPipe.HOST, p.getProps().get(CassandraPipe.HOST));
-				//df.createCassandraTable(p.get("keyspace"), p.get("table"), opPk, opCl, CassandraConnector.apply(ctx.getConf()));
-				
-				CassandraConnector connector = CassandraConnector.apply(ctx.getConf());
-				try (Session session = connector.openSession()) {
-					ResultSet rs = session.execute("SELECT table_name FROM system_schema.tables WHERE keyspace_name='" 
-								+ p.get(CassandraPipe.KEYSPACE) + "' AND table_name='" + p.get(CassandraPipe.TABLE) + "'");
-					if (rs.all().size() == 0) {
-						List<String> pk =  new ArrayList<String>();
-						if (p.get(CassandraPipe.PRIMARY_KEY) != null) {
-							//pk.add(p.get(CassandraPipe.PRIMARY_KEY));
-							pk = Arrays.asList(p.get(CassandraPipe.PRIMARY_KEY).split(","));
-						}
-						Option<Seq<String>> opPk = Option.apply(JavaConverters.asScalaIteratorConverter(pk.iterator()).asScala().toSeq());
-						List<String> cl =  new ArrayList<String>();
-						
-						if (p.getAddProps()!= null && p.getAddProps().containsKey("clusterBy")) {
-							cl=Arrays.asList(p.getAddProps().get("clusterBy").split(","));
-						}
-						Option<Seq<String>> opCl = Option.apply(JavaConverters.asScalaIteratorConverter(cl.iterator()).asScala().toSeq());
-						
-						DataFrameFunctions df = new DataFrameFunctions(toWrite); 
-						LOG.warn("received cassandra table  - " + p.get(CassandraPipe.KEYSPACE) + " and " + p.get(CassandraPipe.TABLE));
-						df.createCassandraTable(p.get(CassandraPipe.KEYSPACE), p.get(CassandraPipe.TABLE), opPk, opCl, CassandraConnector.apply(ctx.getConf()));
-						if (p.getAddProps()!= null && p.getAddProps().containsKey("indexBy")) {
-							LOG.warn("creating index on cassandra");
-
-							session.execute("CREATE INDEX " +  p.getAddProps().get("indexBy") + p.get(CassandraPipe.KEYSPACE) + "_" +  
-									p.get(CassandraPipe.TABLE) + "_idx ON " + p.get(CassandraPipe.KEYSPACE) + "." +  
-									p.get(CassandraPipe.TABLE) + "(" + p.getAddProps().get("indexBy") + 
-									")");
-						}
-					}
-					else {
-						LOG.warn("existing cassandra table  - " + p.get(CassandraPipe.KEYSPACE) + " and " + p.get(CassandraPipe.TABLE));
-					
-					}
-					
-				}
-				catch(Exception e) {
-					e.printStackTrace();
-					LOG.warn("Writing issue");
-				}*/
-			}
-			else if (p.getProps().containsKey("location")) {
-				LOG.warn("Writing file");
-				writer.save(p.get(FilePipe.LOCATION));
-			}	
-			else if (p.getFormat().equals(Format.JDBC)){
-				writer = toWrite.write();
-				writer = writer.format(p.getFormat().type());				
-
-				if (p.getMode() != null) {
-					writer.mode(p.getMode());
-				}
-				else {
-					writer.mode("Append");
-				}
-				for (String key: p.getProps().keySet()) {
-					writer = writer.option(key, p.get(key));
-				}
-				writer.save();
-			}
-			else {			
-				writer.save();
-			
-			}
-			
-			
+ 			writer.saveAsTable(p.get(FilePipe.TABLENAME));			
 		}
-
 	}
 
-	public static void writePerSource(DataFrame toWrite, Arguments args, JavaSparkContext ctx, Pipe[] pipes ) {
+	public static void writePerSource(DataFrame toWrite, Arguments args, Pipe[] pipes ) {
 		List<Row> sources = Arrays.asList(toWrite.select(ColName.SOURCE_COL).distinct().collect());
 		for (Row r : sources) {
 			DataFrame toWriteNow = toWrite.filter(toWrite.col(ColName.SOURCE_COL).equal_to(Functions.lit(r.get(0))));
 			toWriteNow = toWriteNow.drop(ColName.SOURCE_COL);
-			PipeUtil.write(toWriteNow, args, ctx, pipes);
+			PipeUtil.write(toWriteNow, args, pipes);
 
 		}
 	}

--- a/core/src/main/java/zingg/util/RowAdapter.java
+++ b/core/src/main/java/zingg/util/RowAdapter.java
@@ -1,6 +1,6 @@
 package zingg.util;
 
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.Row;
 
 import freemarker.template.ObjectWrapper;
 import freemarker.template.TemplateModel;

--- a/core/src/main/java/zingg/util/RowWrapper.java
+++ b/core/src/main/java/zingg/util/RowWrapper.java
@@ -2,7 +2,7 @@ package zingg.util;
 
 import freemarker.template.Version;
 
-import org.apache.spark.sql.Row;
+import com.snowflake.snowpark_java.Row;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.TemplateDateModel;
 import freemarker.template.TemplateModel;

--- a/core/src/test/java/zingg/TestDocumenter.java
+++ b/core/src/test/java/zingg/TestDocumenter.java
@@ -2,7 +2,6 @@ package zingg;
 
 import static org.junit.Assert.fail;
 
-import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,14 +11,12 @@ import zingg.client.ZinggClientException;
 
 public class TestDocumenter {
     Arguments args;
-    JavaSparkContext sc;
     
     @Before
     public void setUp(){
 
         try {
 			args = Arguments.createArgumentsFromJSON(getClass().getResource("/testConfig.json").getFile());
-            sc = new JavaSparkContext("local", "JavaAPISuite");
          	//fail("Exception was expected for missing config file");
 		} catch (Throwable e) {
             e.printStackTrace();

--- a/core/src/test/java/zingg/TestFebrlDataset.java
+++ b/core/src/test/java/zingg/TestFebrlDataset.java
@@ -2,9 +2,6 @@ package zingg;
 
 import java.io.File;
 
-import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,17 +14,13 @@ import scala.Tuple2;
 
 public class TestFebrlDataset {
 	
-	private transient JavaSparkContext sc;
 	
 	@Before
     public void setUp() throws Exception, ZinggClientException{
-      sc = new JavaSparkContext("local", "JavaAPISuite");
     }
 
     @After
     public void tearDown() {
-      sc.stop();
-      sc = null;
       // To avoid Akka rebinding to the same port, since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.driver.port");
     }

--- a/core/src/test/java/zingg/util/TestUtil.java
+++ b/core/src/test/java/zingg/util/TestUtil.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.spark.sql.types.DataType;
 import org.junit.Test;
 
 import zingg.client.util.*;

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>com.snowflake</groupId>
 			<artifactId>snowpark</artifactId>
-			<version>1.0.0</version>
+			<version>1.2.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -131,43 +131,8 @@
 		</dependency>
 		<dependency>
 				<groupId>net.snowflake</groupId>
-				<artifactId>spark-snowflake_${scala.binary.version}</artifactId>
-				<version>2.9.0-spark_${spark.binary.version}</version>
-		</dependency>
-		<dependency>
-				<groupId>net.snowflake</groupId>
 				<artifactId>snowflake-jdbc</artifactId>
 				<version>3.13.5</version>
-		</dependency>
-		<dependency>
-			<!-- https://mvnrepository.com/artifact/com.datastax.spark/spark-cassandra-connector -->
-			<groupId>com.datastax.spark</groupId>
-			<artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-			<version>${cassandra.conn.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-mllib_${scala.binary.version}</artifactId>
-			<version>${spark.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_${scala.binary.version}</artifactId>
-			<version>${spark.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-graphx_${scala.binary.version}</artifactId>
-			<version>${spark.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>			<!-- Spark dependency -->
 			<groupId>org.scala-lang</groupId>
@@ -219,11 +184,6 @@
 		</dependency>	
 		-->
 		<dependency>
-			<groupId>graphframes</groupId>
-			<artifactId>graphframes</artifactId>
-			<version>${graphframes.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>${log4j.version}</version>
@@ -236,11 +196,6 @@
 			<version>1.1.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.crealytics/spark-excel -->
-		<dependency>
-			<groupId>com.crealytics</groupId>
-			<artifactId>spark-excel_${scala.binary.version}</artifactId>
-			<version>3.1.2_0.16.5-pre1</version>
-		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>
@@ -316,6 +271,9 @@
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.source}</target>
+					<excludes>
+						<exclude>**/sink/Sinker.java</exclude>
+					</excludes>
 					<showWarnings>true</showWarnings>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Replaced with snowflake_java api. Cleaner code.  Now have vararg (Column ..) based functions

However, below are the few things which are need to be resolveed

a) filter() -> as arg two columns are compared by equalTo(Column) ..
    earlier used $eq$eq$eq,  but in java api no equal_to(Object) function
    .in(Object) is the nearest one but there is no not_in(Object) function
b) Row().getAs("ColumnName") fn is not there rather Row().get(Index) is present....Need to get convert from column index
c) DF.Util()    GraphFrame is spark based
d) persist(), rapartition(0 etc. are WIP for snowpark



