### PR TITLE
New option/config showconcise

### DIFF
--- a/client/src/main/java/zingg/client/Arguments.java
+++ b/client/src/main/java/zingg/client/Arguments.java
@@ -102,7 +102,8 @@ public class Arguments implements Serializable {
 	String modelId = "1";
 	double threshold = 0.5d;
 	int jobId = 1;
-	boolean collectMetrics = true; 
+	boolean collectMetrics = true;
+	boolean showConcise = false;
 	
 	private static final String ENV_VAR_MARKER_START = "$";
 	private static final String ENV_VAR_MARKER_END = "$";
@@ -598,6 +599,14 @@ public class Arguments implements Serializable {
 		this.collectMetrics = collectMetrics;
 	}
 
+	public boolean getShowConcise() {
+		return showConcise;
+	}
+
+	public void setShowConcise(boolean showConcise) {
+		this.showConcise = showConcise;
+	}
+	
 	public String[] getPipeNames() {
 		Pipe[] input = this.getData();
 		String[] sourceNames = new String[input.length];

--- a/client/src/main/java/zingg/client/Client.java
+++ b/client/src/main/java/zingg/client/Client.java
@@ -86,6 +86,10 @@ public class Client implements Serializable {
 			String j = options.get(options.COLLECT_METRICS).value;
 			args.setCollectMetrics(Boolean.valueOf(j));
 		}
+		if (options.get(ClientOptions.SHOW_CONCISE)!= null) {
+			String j = options.get(ClientOptions.SHOW_CONCISE).value;
+			args.setShowConcise(Boolean.valueOf(j));
+		}
 		setArguments(args);
 	}
 	

--- a/client/src/main/java/zingg/client/ClientOptions.java
+++ b/client/src/main/java/zingg/client/ClientOptions.java
@@ -27,6 +27,7 @@ public class ClientOptions {
 	public static final String ZINGG_DIR = "--zinggDir";
 	public static final String MODEL_ID = "--modelId";
 	public static final String COLLECT_METRICS = "--collectMetrics";
+	public static final String SHOW_CONCISE = "--showConcise";
 	
 	 // Options that do not take arguments.
 	public static final String HELP = "--help";
@@ -55,6 +56,7 @@ public class ClientOptions {
 		optionMaster.put(ZINGG_DIR, new Option(ZINGG_DIR, true, "location of Zingg models, defaults to /tmp/zingg", false, false));
 		optionMaster.put(MODEL_ID, new Option(MODEL_ID, true, "model identifier, can be a number ", false, false));
 		optionMaster.put(COLLECT_METRICS, new Option(COLLECT_METRICS, true, "collect analytics, true/false  ", false, false));
+		optionMaster.put(SHOW_CONCISE, new Option(SHOW_CONCISE, true, "Display only fields that are used to make model, true/false  ", false, false));
 				
 		//no args
 		optionMaster.put(HELP,new Option(HELP,  false, "print usage information", true, false));

--- a/core/src/main/java/zingg/LabelUpdater.java
+++ b/core/src/main/java/zingg/LabelUpdater.java
@@ -48,7 +48,7 @@ public class LabelUpdater extends Labeller {
 			return;
 		}
 
-		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false);
+		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false, args.getShowConcise());
 		try {
 			int matchFlag;
 			Dataset<Row> updatedRecords = null;

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -82,7 +82,7 @@ public class Labeller extends ZinggBase {
 		}
 
 		lines = lines.cache();
-		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false);
+		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false, args.getShowConcise());
 
 		List<Row> clusterIDs = lines.select(ColName.CLUSTER_COLUMN).distinct().collectAsList();
 		try {

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -175,12 +175,15 @@ public class DSUtil {
 		
 	}
 
-	public static List<Column> getFieldDefColumns (Dataset<Row> ds, Arguments args, boolean includeZid) {
+	public static List<Column> getFieldDefColumns (Dataset<Row> ds, Arguments args, boolean includeZid, boolean showConcise) {
 		List<Column> cols = new ArrayList<Column>();
 		if (includeZid) {
 			cols.add(ds.col(ColName.ID_COL));						
 		}
 		for (FieldDefinition def: args.getFieldDefinition()) {
+			if (showConcise && def.matchType == MatchType.DONT_USE) {
+				continue;
+			}
 			cols.add(ds.col(def.fieldName));						
 		}
 		cols.add(ds.col(ColName.SOURCE_COL));
@@ -189,7 +192,7 @@ public class DSUtil {
 	}
 
 	public static Dataset<Row> getFieldDefColumnsDS(Dataset<Row> ds, Arguments args, boolean includeZid) {
-		return select(ds, getFieldDefColumns(ds, args, includeZid));
+		return select(ds, getFieldDefColumns(ds, args, includeZid, false));
 	}
 
 	public static Dataset<Row> select(Dataset<Row> ds, List<Column> cols) {

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -89,13 +89,16 @@ Name says it :-) Appears in the output but no computation is done on these. Help
   ]
 ````
 
-In the above example, field id from input is present in the output but not used for comparisons.   
+In the above example, field id from input is present in the output but not used for comparisons. Also, these fileds may not be shown to the user while labelling, if [showConcise](#showconcise) is set true.
 
 ### numPartitions
 Number of Spark partitions over which the input data is distributed. Keep it equal to the 20-30 times the number of cores. This is an important configuration for performance.
 
 ### labelDataSampleSize
 Fraction of the data to be used for training the models. Adjust it between 0.0001 and 0.1 to keep the sample size small enough so that it finds enough edge cases fast. If the size is bigger, the findTrainingData job will spend more time combing through samples. If the size is too small, Zingg may not find the right edge cases. 
+
+### showConcise
+When this flag is set to true, during [Label](./training/label.md) and [updateLabel](../updatingLabels.md), only those fields are displayed on console which help build the model. In other words, fields that have matchType as "DONT_USE", are not displayed to the user. Default is false. 
 
 ### collectMetrics
 Application captures a few measurements for runtime metrics such as *no. of data records, no. of features, running phase* and a few more. 

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -89,7 +89,7 @@ Name says it :-) Appears in the output but no computation is done on these. Help
   ]
 ````
 
-In the above example, field id from input is present in the output but not used for comparisons. Also, these fileds may not be shown to the user while labelling, if [showConcise](#showconcise) is set true.
+In the above example, field id from input is present in the output but not used for comparisons. Also, these fields may not be shown to the user while labelling, if [showConcise](#showconcise) is set true.
 
 ### numPartitions
 Number of Spark partitions over which the input data is distributed. Keep it equal to the 20-30 times the number of cores. This is an important configuration for performance.


### PR DESCRIPTION
To control the display of fields of matchType "DONT_USE" during Labelling and updateLabelling, following has been added.
a) --showConcise cli option
b) showconcise config parameter

#169