### PR TITLE
Handling Null pointer errors in reading data; proper messaging in jobs

### DIFF
--- a/core/src/main/java/zingg/LabelUpdater.java
+++ b/core/src/main/java/zingg/LabelUpdater.java
@@ -41,6 +41,10 @@ public class LabelUpdater extends Labeller {
 
 	public void processRecordsCli(Dataset<Row> lines) throws ZinggClientException {
 		LOG.info("Processing Records for CLI updateLabelling");
+		if (lines == null || lines.count() == 0) {
+			LOG.info("It seems there is no previously labeled record. Please run 'label' job to label pairs of records.");
+			return;
+		}
 		getMarkedRecordsStat(lines);
 		printMarkedRecordsStat();
 		if (lines == null || lines.count() == 0) {

--- a/core/src/main/java/zingg/Labeller.java
+++ b/core/src/main/java/zingg/Labeller.java
@@ -75,11 +75,11 @@ public class Labeller extends ZinggBase {
 
 	public void processRecordsCli(Dataset<Row> lines) throws ZinggClientException {
 		LOG.info("Processing Records for CLI Labelling");
-		printMarkedRecordsStat();
 		if (lines == null || lines.count() == 0) {
 			LOG.info("It seems there are no unmarked records at this moment. Please run findTrainingData job to build some pairs to be labelled and then run this labeler.");
 			return;
 		}
+		printMarkedRecordsStat();
 
 		lines = lines.cache();
 		List<Column> displayCols = DSUtil.getFieldDefColumns(lines, args, false, args.getShowConcise());

--- a/core/src/main/java/zingg/Matcher.java
+++ b/core/src/main/java/zingg/Matcher.java
@@ -41,8 +41,13 @@ public class Matcher extends ZinggBase{
         setZinggOptions(ZinggOptions.MATCH);
     }
 
-	protected Dataset<Row> getTestData() {
-		return PipeUtil.read(spark, true, args.getNumPartitions(), true, args.getData());
+	protected Dataset<Row> getTestData() throws ZinggClientException{
+		Dataset<Row> data = PipeUtil.read(spark, true, args.getNumPartitions(), true, args.getData());
+		if (data == null || data.isEmpty()) {
+			throw new ZinggClientException(
+					"Test Data is missing or empty. Matching cannot be done.");
+		}
+		return data;
 	}
 
 	protected Dataset<Row> getBlocked(Dataset<Row> testData) throws Exception{

--- a/core/src/main/java/zingg/TrainingDataFinder.java
+++ b/core/src/main/java/zingg/TrainingDataFinder.java
@@ -51,6 +51,10 @@ public class TrainingDataFinder extends ZinggBase{
     public void execute() throws ZinggClientException {
 			try{
 				Dataset<Row> data = PipeUtil.read(spark, true, true, args.getData());
+				if (data == null || data.isEmpty()) {
+					throw new ZinggClientException(
+							"Test Data is missing or empty. 'findTrainingData' job cannot be executed.");
+				}
 				LOG.warn("Read input data " + data.count());
 				//create 20 pos pairs
 

--- a/core/src/main/java/zingg/util/BlockingTreeUtil.java
+++ b/core/src/main/java/zingg/util/BlockingTreeUtil.java
@@ -88,6 +88,10 @@ public class BlockingTreeUtil {
 
 	public static Tree<Canopy> readBlockingTree(SparkSession spark, Arguments args) throws Exception {
 		Dataset<Row> tree = PipeUtil.read(spark, false, args.getNumPartitions(), false, PipeUtil.getBlockingTreePipe(args));
+		if (tree == null || tree.isEmpty()) {
+			throw new Exception(
+					"Blocking Tree is missing. Matching cannot be done. Please train the model first.");
+		}
 		byte [] byteArrayBack = (byte[]) tree.head().get(0);
 		Tree<Canopy> blockingTree = null;
 		blockingTree =  (Tree<Canopy>) Util.revertObjectFromByteArray(byteArrayBack);

--- a/core/src/main/java/zingg/util/DSUtil.java
+++ b/core/src/main/java/zingg/util/DSUtil.java
@@ -233,6 +233,9 @@ public class DSUtil {
 			trFile = PipeUtil.read(spark, 
 					false, false, p); 
 			LOG.warn("Read marked training samples ");
+			if (trFile == null || trFile.isEmpty()) {
+				throw new Exception("No preexisting marked training samples");
+			}
 			trFile = trFile.drop(ColName.PREDICTION_COL);
 			trFile = trFile.drop(ColName.SCORE_COL);				
 		}


### PR DESCRIPTION
* If there is exception in PipeUtil.read(), handle it and log the message.
* At all the places, where the input has null has null value, has been handled. Particularly in the flow of  the trainer use case.
* Null input from the read is not fatal in all the cases. However, a fatal exception is thrown, where the job cannot be performed further. that is in main flow's execute() and around.