### PR TITLE
Documenter JUnit tests

### DIFF
--- a/core/src/main/java/zingg/documenter/ColumnDocumenter.java
+++ b/core/src/main/java/zingg/documenter/ColumnDocumenter.java
@@ -17,7 +17,6 @@ import zingg.client.Arguments;
 import zingg.client.FieldDefinition;
 import zingg.client.MatchType;
 import zingg.client.ZinggClientException;
-import zingg.client.util.ColName;
 import zingg.util.PipeUtil;
 
 public class ColumnDocumenter extends DocumenterBase {
@@ -35,7 +34,7 @@ public class ColumnDocumenter extends DocumenterBase {
 		createColumnDocuments();
 	}
 
-	private void createColumnDocuments() throws ZinggClientException {
+	protected void createColumnDocuments() throws ZinggClientException {
 		LOG.info("Column Documents generation starts");
 
 		Dataset<Row> data = PipeUtil.read(spark, false, false, args.getData());

--- a/core/src/test/java/zingg/TestDocumenter.java
+++ b/core/src/test/java/zingg/TestDocumenter.java
@@ -1,38 +1,128 @@
 package zingg;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.apache.spark.api.java.JavaSparkContext;
-import org.junit.jupiter.api.AfterEach;
+import java.io.File;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import zingg.client.Arguments;
 import zingg.client.ZinggClientException;
+import zingg.client.pipe.FilePipe;
+import zingg.client.pipe.Pipe;
+import zingg.documenter.TestBaseDocumenter;
 
-public class TestDocumenter {
-    Arguments args;
-    JavaSparkContext sc;
-    
-    @BeforeEach
-    public void setUp(){
+public class TestDocumenter extends TestBaseDocumenter {
 
-        try {
+	@BeforeEach
+	public void setUp() {
+
+		try {
 			args = Arguments.createArgumentsFromJSON(getClass().getResource("/testConfig.json").getFile());
-            sc = new JavaSparkContext("local", "JavaAPISuite");
-         	//fail("Exception was expected for missing config file");
+			//fail("Exception was expected for missing config file");
 		} catch (Throwable e) {
-            e.printStackTrace();
+			e.printStackTrace();
 			System.out.println("Unexpected exception received " + e.getMessage());
-            fail(e.getMessage());
+			fail(e.getMessage());
 		}
-    }
+	}
 
-    @Test
-    public void testOutput() throws Throwable{
-        Documenter doc = new Documenter();
-        doc.init(args, "");
-        doc.setArgs(args);
-        doc.execute();
-    }
+	@Test
+	public void testOutput() throws Throwable {
+		try {
+			args = Arguments.createArgumentsFromJSON(getClass().getResource("/testConfig.json").getFile());
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Unexpected exception received " + e.getMessage());
+			fail(e.getMessage());
+		}
+
+		Documenter doc = new Documenter();
+		doc.init(args, "");
+		doc.setArgs(args);
+		doc.execute();
+	}
+
+	@Test
+	public void testDocumenterWhenModelIsNotYetAvailable() {
+		String rootDir = getRootDir();
+		try {
+			args = Arguments.createArgumentsFromJSON(rootDir + "/examples/amazon-google/config.json");
+
+			Pipe p = args.getData()[0]; 
+			p.setProp(FilePipe.LOCATION, "../examples/amazon-google/Amazon.csv");
+			Pipe[] newData = {p};
+			args.setData(newData);
+
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Unexpected exception received " + e.getMessage());
+			fail(e.getMessage());
+		}
+		
+		Documenter doc = new Documenter();
+		// Set a new model id that is not used. Model Doc should have any data but generation of other docs should not be impacted
+		args.setModelId("9999");
+		args.setZinggDir("../models");
+		try {
+			doc.init(args, "");
+			doc.setArgs(args);
+			doc.execute();
+
+			File modelFile = new File(args.getZinggDocFile());
+			assertEquals(true, modelFile.exists());
+			assertModelFleSize(modelFile.length() < DEFAULT_FILE_SIZE, modelFile.length());
+			
+			File directory = new File(args.getZinggDocDir());
+			assertEquals(true, directory.exists(), "Zingg Directory does not exist. Docs haven't been generated. " + args.getZinggDocDir());
+
+			File[] listOfFiles = directory.listFiles((dir, name) -> name.endsWith(".html"));
+			assertNotEquals(listOfFiles.length, 0, "No. of generated html documents is not proper. Length: " + listOfFiles.length);
+		} catch (ZinggClientException e) {	
+			e.printStackTrace();
+		}
+	}
+
+
+	@Test
+	public void testDocumenterForAmazonGoogleModel() {
+		String rootDir = getRootDir();
+		try {
+			args = Arguments.createArgumentsFromJSON(rootDir + "/examples/amazon-google/config.json");
+			
+			Pipe p = args.getData()[0]; 
+			p.setProp(FilePipe.LOCATION, "../examples/amazon-google/Amazon.csv");
+			Pipe[] newData = {p};
+			args.setData(newData);
+			args.setZinggDir("../models");
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Unexpected exception received " + e.getMessage());
+			fail(e.getMessage());
+		}
+
+		Documenter doc = new Documenter();
+		try {
+			doc.init(args, "");
+			doc.setArgs(args);
+			doc.execute();
+
+			File modelFile = new File(args.getZinggDocFile());
+			assertEquals(true, modelFile.exists(), "Doc file hasn't been generated. " + args.getZinggDocFile());
+			assertModelFleSize(modelFile.length() > DEFAULT_FILE_SIZE, modelFile.length());
+
+			File directory = new File(args.getZinggDocDir());
+			assertEquals(true, directory.exists(), "Zingg Directory does not exist. Column docs haven't been generated. " + args.getZinggDocDir());
+
+			File[] listOfFiles = directory.listFiles((dir, name) -> name.endsWith(".html"));
+			if(listOfFiles.length == 0) {
+				fail("Zingg Directory does exist but Column docs haven't been generated.");
+			}
+		} catch (ZinggClientException e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/core/src/test/java/zingg/documenter/TestBaseDocumenter.java
+++ b/core/src/test/java/zingg/documenter/TestBaseDocumenter.java
@@ -1,0 +1,24 @@
+package zingg.documenter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import zingg.BaseSparkTest;
+
+public class TestBaseDocumenter extends BaseSparkTest {
+
+    public static final int DEFAULT_FILE_SIZE = 2000;
+
+	protected void assertModelFleSize(Boolean condition, long length) {
+		assertTrue(condition, "Size of file " + args.getZinggDocFile() + " is " + length + ". Expected size " + DEFAULT_FILE_SIZE);
+	}
+
+	protected String getRootDir() {
+		File resourcesDirectory = new File("src/test/resources");
+		String absolutePath = resourcesDirectory.getAbsolutePath();
+		String rootDir = absolutePath.substring( 0, absolutePath.indexOf( "core/src/test/resources" ) );
+		return rootDir;
+	}
+
+}

--- a/core/src/test/java/zingg/documenter/TestColumnDocumenter.java
+++ b/core/src/test/java/zingg/documenter/TestColumnDocumenter.java
@@ -1,0 +1,58 @@
+package zingg.documenter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import zingg.client.Arguments;
+import zingg.client.MatchType;
+import zingg.client.ZinggClientException;
+import zingg.util.DSUtil;
+
+public class TestColumnDocumenter extends TestBaseDocumenter {
+  
+	public static final Log LOG = LogFactory.getLog(TestColumnDocumenter.class);
+
+	@BeforeEach
+	public void setUp() {
+
+		try {
+			args = Arguments.createArgumentsFromJSON(getClass().getResource("/testConfig.json").getFile());
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Unexpected exception received " + e.getMessage());
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testCreateColumnDocuments() {
+		ColumnDocumenter cd = new ColumnDocumenter(spark, args);
+		try {
+			cd.createColumnDocuments();
+		} catch (ZinggClientException e) {
+			e.printStackTrace();
+		}
+
+		File directory = new File(args.getZinggDocDir());
+		LOG.info("Directory Name: " + args.getZinggDocDir());
+		assertEquals(true, directory.exists(), "Zingg Directory does not exist. Docs haven't been generated. " + args.getZinggDocDir());
+
+		File[] listOfFiles = directory.listFiles((dir, name) -> name.endsWith(".html"));
+		int htmlDocsCount = DSUtil.getFieldDefinitionFiltered(args, MatchType.DONT_USE).size()
+								+ cd.getZColumnList().size();
+		assertEquals(listOfFiles.length, htmlDocsCount, "No. of generated html documents is not proper. Expected: " + htmlDocsCount + ", Actual: " + listOfFiles.length);
+
+		String stopWordsDir = args.getZinggDocDir() + "/stopWords/";
+		File directoryStopWord = new File(stopWordsDir);
+		File[] listOfStopWordsFiles = directoryStopWord.listFiles((dir, name) -> name.endsWith(".csv"));
+		int csvDocsCount = htmlDocsCount;
+		assertEquals(listOfStopWordsFiles.length, csvDocsCount, "No. of generated stopWord files is not proper. Expected: " + csvDocsCount + ", Actual: " + listOfStopWordsFiles.length);
+	}
+}

--- a/core/src/test/java/zingg/documenter/TestModelDocumenter.java
+++ b/core/src/test/java/zingg/documenter/TestModelDocumenter.java
@@ -1,0 +1,47 @@
+package zingg.documenter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import zingg.client.Arguments;
+import zingg.client.ZinggClientException;
+import zingg.client.pipe.FilePipe;
+import zingg.client.pipe.Pipe;
+
+public class TestModelDocumenter extends TestBaseDocumenter {
+    @Test
+	public void testCreateModelDocument(){
+		String rootDir = getRootDir();
+		try {
+			args = Arguments.createArgumentsFromJSON(rootDir + "/examples/iTunes-amazon/config.json");
+			
+			Pipe p = args.getData()[0]; 
+			p.setProp(FilePipe.LOCATION, "../examples/iTunes-amazon/iTunesMusic.csv");
+			Pipe[] newData = {p};
+			args.setData(newData);
+			args.setZinggDir("../models");
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.out.println("Unexpected exception received " + e.getMessage());
+			fail(e.getMessage());
+		}
+
+		ModelDocumenter md = new ModelDocumenter(spark, args);
+		try {
+			md.process();
+		} catch (ZinggClientException e) {
+			e.printStackTrace();
+		}
+
+		File modelFile = new File(args.getZinggDocFile());
+		assertEquals(true, modelFile.exists(), "Doc file hasn't been generated. " + args.getZinggDocFile());
+		assertModelFleSize(modelFile.length() > DEFAULT_FILE_SIZE, modelFile.length());
+
+		File directory = new File(args.getZinggDocDir());
+		assertEquals(true, directory.exists(), "Zingg Directory does not exist. Column docs haven't been generated. " + args.getZinggDocDir());
+	}
+}


### PR DESCRIPTION
Separate test files for Model, Column and (Main) Documenter classes.
use datasets/model  iTunes-amazon (model id 105), amazon-google (103), febrl (100)