### PR TITLE
Removed dependencies of snowflake, mysql, cassandra, elastic, apache-poi, log4j from pom

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>zingg</groupId>
@@ -13,54 +12,35 @@
 		<fasterxml.jackson.databind.version>2.12.6.1</fasterxml.jackson.databind.version>
 	</properties>
 	<dependencies>
-
-<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi</artifactId>
-			<version>3.17</version>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${fasterxml.jackson.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-			<version>3.16</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${fasterxml.jackson.databind.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-scratchpad</artifactId>
-			<version>5.2.1</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>${fasterxml.jackson.version}</version>
 		</dependency>
-			 <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${fasterxml.jackson.version}</version>
-			<scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.jackson.databind.version}</version>
-			<scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${fasterxml.jackson.version}</version>
-      </dependency>
-		
-
-</dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>
-			 <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
-          <configuration>
-              <sourcepath>${basedir}/src/main/java/zingg/client</sourcepath>
-          </configuration>
-        </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<configuration>
+					<sourcepath>${basedir}/src/main/java/zingg/client</sourcepath>
+				</configuration>
+			</plugin>
 		</plugins>
-		
 	</build>
 </project>

--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -38,12 +38,12 @@ import scala.collection.Seq;
 //import com.datastax.driver.core.ResultSet;
 //import com.datastax.driver.core.Session;
 //import com.datastax.spark.connector.DataFrameFunctions;
-import com.datastax.spark.connector.cql.CassandraConnector;
-import com.datastax.spark.connector.cql.ClusteringColumn;
-import com.datastax.spark.connector.cql.ColumnDef;
-import com.datastax.spark.connector.cql.TableDef;
+// import com.datastax.spark.connector.cql.CassandraConnector;
+// import com.datastax.spark.connector.cql.ClusteringColumn;
+// import com.datastax.spark.connector.cql.ColumnDef;
+// import com.datastax.spark.connector.cql.TableDef;
 
-import com.datastax.spark.connector.cql.*;
+// import com.datastax.spark.connector.cql.*;
 import zingg.scala.DFUtil;
 
 //import com.datastax.spark.connector.cql.*;

--- a/docs/dataSourcesAndSinks/snowflake.md
+++ b/docs/dataSourcesAndSinks/snowflake.md
@@ -24,4 +24,9 @@ The config value for the data and output attributes of the JSON is
 				"dbtable": "FEBRL"				
 			}
 		} ]
-``` 
+```
+
+One must include Snowflake JDBC driver and Spark dependency on the spark classpath. Please set the following environment variable before running Zingg. The jars can be downloaded from maven repositary ([1](https://mvnrepository.com/artifact/net.snowflake/snowflake-jdbc), [2](https://mvnrepository.com/artifact/net.snowflake/spark-snowflake))
+```
+export ZINGG_EXTRA_JARS=snowflake-jdbc-3.13.18.jar,spark-snowflake_2.12-2.10.0-spark_3.1.jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 				<spark.binary.version>3.1</spark.binary.version>
 				<scala.binary.version>2.12</scala.binary.version>
 				<graphframes.version>0.8.1-spark3.0-s_2.12</graphframes.version>
-				<cassandra.conn.version>3.0.0</cassandra.conn.version>
 			</properties>
 		</profile>
 		<profile>
@@ -61,7 +60,6 @@
 				<spark.binary.version>3.0</spark.binary.version>
 				<scala.binary.version>2.12</scala.binary.version>
 				<graphframes.version>0.8.1-spark3.0-s_2.12</graphframes.version>
-				<cassandra.conn.version>3.0.0</cassandra.conn.version>
 			</properties>
 		</profile>
 		<profile>
@@ -78,7 +76,6 @@
 				<spark.binary.version>2.4</spark.binary.version>
 				<scala.binary.version>2.11</scala.binary.version>
 				<graphframes.version>0.8.1-spark2.4-s_2.11</graphframes.version>
-				<cassandra.conn.version>3.0.0-alpha2</cassandra.conn.version>
 			</properties>
 		</profile>
 	</profiles>
@@ -96,7 +93,6 @@
 		<maven-jar-plugin.version>2.3.2</maven-jar-plugin.version>
 		<commons.lang.version>2.3</commons.lang.version>
 		<shade.plugin.version>2.4.3</shade.plugin.version>
-		<log4j.version>1.2.17</log4j.version>
 		<mainClass>zingg.client.Client</mainClass>
 		<spark.master>spark://pc-sonal2:7077</spark.master>
 	</properties>
@@ -110,40 +106,6 @@
 	</repositories>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.elasticsearch</groupId>
-			<artifactId>elasticsearch-spark-20_2.11</artifactId>
-			<version>7.2.0</version>
-			<scope>compile</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>net.snowflake</groupId>
-			<artifactId>spark-snowflake_${scala.binary.version}</artifactId>
-			<version>2.9.0-spark_${spark.binary.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>net.snowflake</groupId>
-			<artifactId>snowflake-jdbc</artifactId>
-			<version>3.13.5</version>
-		</dependency>
-		<dependency>
-			<!-- https://mvnrepository.com/artifact/com.datastax.spark/spark-cassandra-connector -->
-			<groupId>com.datastax.spark</groupId>
-			<artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-			<version>${cassandra.conn.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-mllib_${scala.binary.version}</artifactId>
@@ -177,11 +139,6 @@
   			<scope>provided</scope>
 		</dependency>
 		-->
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.20</version>
-		</dependency>
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
@@ -223,12 +180,6 @@
 			<groupId>graphframes</groupId>
 			<artifactId>graphframes</artifactId>
 			<version>${graphframes.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>${log4j.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
 		<dependency>


### PR DESCRIPTION
Dependencies of snowflake, mysql etc. have been removed from pom. However, their support in Zingg continues to be available. The environment varible **ZINGG_EXTRA_JARS** must be set to point to the jars of concerned data source. More in  Zingg [docs](https://docs.zingg.ai/zingg/connectors/snowflake)