### PR TITLE
Updated installation document to install maven using sudo apt

### DIFF
--- a/docs/settingUpZingg.md
+++ b/docs/settingUpZingg.md
@@ -12,9 +12,11 @@ The following steps will help you setup the Zingg Development Environment. While
 * Download Apache Spark - version spark-3.1.2-bin-hadoop3.2 from the [Apache Spark Official Website](https://spark.apache.org/downloads.html)
 * Install Downloaded Apache Spark - version spark-3.1.2-bin-hadoop3.2 on your Ubuntu by following [this tutorial](https://computingforgeeks.com/how-to-install-apache-spark-on-ubuntu-debian/)
 
-**Step 4: Install Apache Maven 3.3.9**
-* Download Apache Maven 3.3.9 ‘.tar.gz’ file from the [Apache Maven Official Website](https://maven.apache.org/download.cgi)
-* Install the downloaded Apache Maven file using [this tutorial](https://www.linuxhelp.com/how-to-install-apache-maven-3-3-9-on-linux-mint-18-3)
+**Step 4: Install Apache Maven**
+* Install latest maven package using following linux command
+```
+sudo apt install maven
+```
 
 **Step 5: Set JAVA_HOME to JDK base directory**
 * Go to **cd /etc** directory in your Ubuntu system, and open the **‘profile’ file** using gedit. Just run **sudo gedit profile**

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -93,7 +93,7 @@ Congratulations, Zingg has been installed!
 ## Compiling from sources
 If you need to compile the latest code or build for a different Spark version, you can clone this repo and 
 
-- Install maven (We are on version 3.3.9)
+- Install maven
 - Install JDK 1.8
 - Set JAVA_HOME to JDK base directory
 - Run the following


### PR DESCRIPTION
Changed to standard installation method for maven that is using "apt install".
Any version of maven shall work. Latest one should be preferred.(on date, it is 3.6.3)