### PR TITLE
throw error if format is null; happens due to invalid/unsopprted format configuration

### DIFF
--- a/core/src/main/java/zingg/util/PipeUtil.java
+++ b/core/src/main/java/zingg/util/PipeUtil.java
@@ -55,11 +55,15 @@ public class PipeUtil {
 
 	public static final Log LOG = LogFactory.getLog(PipeUtil.class);
 
-	private static DataFrameReader getReader(SparkSession spark, Pipe p) {
+	private static DataFrameReader getReader(SparkSession spark, Pipe p) throws ZinggClientException {
 		DataFrameReader reader = spark.read();
-
-		LOG.warn("Reading input " + p.getFormat().type());
-		reader = reader.format(p.getFormat().type());
+		if (p.getFormat() != null) {
+			LOG.warn("Reading input " + p.getFormat().type());
+			reader = reader.format(p.getFormat().type());
+		} else { // throw error, if a valid/supported format is a not configured
+			LOG.warn(p.toString());
+			throw new ZinggClientException("Format is null");
+		}
 		if (p.getSchema() != null) {
 			reader = reader.schema(p.getSchema());
 		}

--- a/core/src/test/java/zingg/util/TestPipeUtil.java
+++ b/core/src/test/java/zingg/util/TestPipeUtil.java
@@ -1,0 +1,55 @@
+package zingg.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+
+import zingg.ZinggSparkTester;
+import zingg.client.pipe.FilePipe;
+import zingg.client.pipe.Format;
+import zingg.client.pipe.Pipe;
+
+public class TestPipeUtil extends ZinggSparkTester {
+	public static final Log LOG = LogFactory.getLog(TestPipeUtil.class);
+
+	@Test
+	public void testGetDataFRameReaderforGivenFormat() throws Exception {
+		Method f = PipeUtil.class.getDeclaredMethod("getReader", SparkSession.class, Pipe.class);
+		f.setAccessible(true);
+
+		Pipe p = new Pipe();
+		p.setName("InvalidFormat");
+		p.setFormat(null);
+		p.setProp(FilePipe.HEADER, "true");
+		try {
+			Object reader = f.invoke(null, spark, p);
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			LOG.warn(e.getCause().getMessage());
+			assertEquals("Format is null", e.getCause().getMessage());
+		}
+	}
+
+	@Test
+	public void testGetDataFRameReaderforGivenValidFormat() throws Exception {
+		Method f = PipeUtil.class.getDeclaredMethod("getReader", SparkSession.class, Pipe.class);
+		f.setAccessible(true);
+
+		Pipe p = new Pipe();
+		p.setName("ValidFormat");
+		p.setFormat(Format.CSV);
+		p.setProp(FilePipe.HEADER, "true");
+		try {
+			Object reader = f.invoke(null, spark, p);
+		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			e.printStackTrace();
+			fail("Format is valid. still getReader() failed. Reason is " + e.getCause().getMessage());
+		}
+	}
+}


### PR DESCRIPTION
An alternative is if we can throw error at the time of parsing config file when we find that format is not included in zingg list.
Also, we may remove restriction of support of only fixed list of formats. Let Spark throw error if it is an invalid/unsupported format.

Testcases for valid as well as invalid format added.
