### PR TITLE
Null Pointer check in "Range" hash functions

### DIFF
--- a/core/src/main/java/zingg/hash/RangeDbl.java
+++ b/core/src/main/java/zingg/hash/RangeDbl.java
@@ -17,7 +17,7 @@ public class RangeDbl extends HashFunction implements UDF1<Double, Integer> {
 	@Override
 	public Integer call(Double field) {
 		int withinRange = 0;
-		if (field >= lowerLimit && field < upperLimit) {
+		if (field != null && field >= lowerLimit && field < upperLimit) {
 			withinRange = 1;
 		}
 		return withinRange;

--- a/core/src/main/java/zingg/hash/RangeInt.java
+++ b/core/src/main/java/zingg/hash/RangeInt.java
@@ -17,7 +17,7 @@ public class RangeInt extends HashFunction implements UDF1<Integer, Integer> {
 	@Override
 	public Integer call(Integer field) {
 		int withinRange = 0;
-		if (field >= lowerLimit && field < upperLimit) {
+		if (field != null && field >= lowerLimit && field < upperLimit) {
 			withinRange = 1;
 		}
 		return withinRange;

--- a/core/src/test/java/zingg/hash/TestLessThanZeroInt.java
+++ b/core/src/test/java/zingg/hash/TestLessThanZeroInt.java
@@ -14,7 +14,7 @@ public class TestLessThanZeroInt {
 	}
 
 	@Test
-	public void testLessThanZeroDblForValueNull() {
+	public void testLessThanZeroIntForValueNull() {
 		LessThanZeroInt value = new LessThanZeroInt();
 		assertFalse(value.call(null));
 	}

--- a/core/src/test/java/zingg/hash/TestLessThanZeroInt.java
+++ b/core/src/test/java/zingg/hash/TestLessThanZeroInt.java
@@ -15,7 +15,7 @@ public class TestLessThanZeroInt {
 
 	@Test
 	public void testLessThanZeroDblForValueNull() {
-		LessThanZeroDbl value = new LessThanZeroDbl();
+		LessThanZeroInt value = new LessThanZeroInt();
 		assertFalse(value.call(null));
 	}
 

--- a/core/src/test/java/zingg/hash/TestRangeBetween0And10Dbl.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween0And10Dbl.java
@@ -48,5 +48,9 @@ public class TestRangeBetween0And10Dbl {
 		RangeDbl value = new RangeBetween0And10Dbl();
 		assertEquals(0, value.call(8637d));
 	}
-
+	@Test
+	public void testRangeForNull() {
+		RangeDbl value = new RangeBetween0And10Dbl();
+		assertEquals(0, value.call(null));
+	}
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween0And10Int.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween0And10Int.java
@@ -46,5 +46,10 @@ public class TestRangeBetween0And10Int {
 		RangeInt value = new RangeBetween0And10Int();
 		assertEquals(0, value.call(8637));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeInt value = new RangeBetween0And10Int();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween1000And10000Dbl.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween1000And10000Dbl.java
@@ -48,5 +48,10 @@ public class TestRangeBetween1000And10000Dbl {
 		RangeDbl value = new RangeBetween1000And10000Dbl();
 		assertEquals(1, value.call(8637d));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeDbl value = new RangeBetween1000And10000Dbl();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween1000And10000Int.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween1000And10000Int.java
@@ -47,5 +47,10 @@ public class TestRangeBetween1000And10000Int {
 		RangeInt value = new RangeBetween1000And10000Int();
 		assertEquals(1, value.call(8637));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeInt value = new RangeBetween1000And10000Int();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween100And1000Dbl.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween100And1000Dbl.java
@@ -49,5 +49,10 @@ public class TestRangeBetween100And1000Dbl {
 		RangeDbl value = new RangeBetween100And1000Dbl();
 		assertEquals(0, value.call(8637d));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeDbl value = new RangeBetween100And1000Dbl();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween100And1000Int.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween100And1000Int.java
@@ -46,5 +46,10 @@ public class TestRangeBetween100And1000Int {
 		RangeInt value = new RangeBetween100And1000Int();
 		assertEquals(0, value.call(8637));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeInt value = new RangeBetween100And1000Int();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween10And100Dbl.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween10And100Dbl.java
@@ -49,5 +49,10 @@ public class TestRangeBetween10And100Dbl {
 		RangeDbl value = new RangeBetween10And100Dbl();
 		assertEquals(0, value.call(8637d));
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeDbl value = new RangeBetween10And100Dbl();
+		assertEquals(0, value.call(null));
+	}
 
 }

--- a/core/src/test/java/zingg/hash/TestRangeBetween10And100Int.java
+++ b/core/src/test/java/zingg/hash/TestRangeBetween10And100Int.java
@@ -46,5 +46,10 @@ public class TestRangeBetween10And100Int {
 		RangeInt value = new RangeBetween10And100Int();
 		assertEquals(0, value.call(8637)); 
 	}
+	@Test
+	public void testRangeForNull() {
+		RangeInt value = new RangeBetween10And100Int();
+		assertEquals(0, value.call(null));
+	}
 
 }


### PR DESCRIPTION
* Handled 'Null' input value in Range set of hash functions. Added testcases also for same.
* All other functions have the null chech. Test cases were also present.
* List of new hash functions recently added
**LessThanZeroInt,LessThanZeroDbl,RangeDbl,RangeInt,,TruncateDouble,TrimLastDigitsInt,TrimLastDigitsDbl**