### PR TITLE
changed 'Format' type from Enum to Class to support new formats by default

### DIFF
--- a/client/src/main/java/zingg/client/pipe/CassandraPipe.java
+++ b/client/src/main/java/zingg/client/pipe/CassandraPipe.java
@@ -10,4 +10,7 @@ public class CassandraPipe extends Pipe{
 	public static final String CLUSTER_BY="clusterBy";
 	public static final String INDEX_BY="indexBy";
 
+	public CassandraPipe() {
+		setFormat(Format.CASSANDRA);
+	}
 }

--- a/client/src/main/java/zingg/client/pipe/Format.java
+++ b/client/src/main/java/zingg/client/pipe/Format.java
@@ -7,22 +7,21 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Format implements Serializable{	
-	
-	
-	CSV ("csv"),
-	JSON("json"),
-	JDBC("jdbc"),
-	ELASTIC("org.elasticsearch.spark.sql"),
-	CASSANDRA("org.apache.spark.sql.cassandra"),
-	XLS("com.crealytics.spark.excel"),
-	XLSX("com.crealytics.spark.excel"),
-	PARQUET("PARQUET"),
-	AVRO("avro"),
-	SNOWFLAKE("net.snowflake.spark.snowflake"),
-	TEXT("text"),
-	BIGQUERY("bigquery"),
-	INMEMORY("inMemory");
+public class Format implements Serializable{
+
+	public static final Format CSV = new Format("csv");
+	public static final Format JSON = new Format("json");
+	public static final Format JDBC = new Format("jdbc");
+	public static final Format ELASTIC = new Format("org.elasticsearch.spark.sql");
+	public static final Format CASSANDRA = new Format("org.apache.spark.sql.cassandra");
+	public static final Format XLS = new Format("com.crealytics.spark.excel");
+	public static final Format XLSX = new Format("com.crealytics.spark.excel");
+	public static final Format PARQUET = new Format("PARQUET");
+	public static final Format AVRO = new Format("avro");
+	public static final Format SNOWFLAKE = new Format("net.snowflake.spark.snowflake");
+	public static final Format TEXT = new Format("text");
+	public static final Format BIGQUERY = new Format("bigquery");
+	public static final Format INMEMORY = new Format("inMemory");
 	
 	String type;
 	static Map<String, Format> map;
@@ -31,16 +30,43 @@ public enum Format implements Serializable{
 		this.type = type;
 	}
 	
-	static{
+	static {
 		map = new HashMap<String, Format>();
-		for (Format p: Format.values()) {
-			map.put(p.type.toLowerCase(), p);
-		}
+		addFormat(CSV);
+		addFormat(JSON);
+		addFormat(JDBC);
+		addFormat(ELASTIC);
+		addFormat(CASSANDRA);
+		addFormat(XLS);
+		addFormat(XLSX);
+		addFormat(PARQUET);
+		addFormat(AVRO);
+		addFormat(SNOWFLAKE);
+		addFormat(TEXT);
+		addFormat(BIGQUERY);
+		addFormat(INMEMORY);
 	}
-	
+
 	@JsonCreator
 	public static Format getPipeType(String t) {
 		return map.get(t.toLowerCase());
+	}
+
+	public static void setPipeType(String t) {
+		map.put(t.toLowerCase(), new Format(t.toLowerCase()));
+	}
+
+	public static Format getFormat(String t) {
+		Format format = map.get(t.toLowerCase());
+		if (format == null) {
+			format = new Format(t);
+			addFormat(format);
+ 		}
+		return format;
+	}
+
+	public static void addFormat(Format f) {
+		map.put(f.type().toLowerCase(), f);
 	}
 
 	@JsonValue
@@ -48,6 +74,10 @@ public enum Format implements Serializable{
 		return type;
 	}
 
+	@Override
+	public String toString() {
+		return type;
+	}
 	
 	
 	

--- a/client/src/main/java/zingg/client/pipe/InMemoryPipe.java
+++ b/client/src/main/java/zingg/client/pipe/InMemoryPipe.java
@@ -6,10 +6,12 @@ import org.apache.spark.sql.Row;
 public class InMemoryPipe extends Pipe{
     
 	public InMemoryPipe() {
+		setFormat(Format.INMEMORY);
 	}
 
 	public InMemoryPipe(Dataset <Row> ds){
 		dataset = ds;
+		setFormat(Format.INMEMORY);
 	}
 
     public Dataset <Row> getRecords() {

--- a/client/src/main/java/zingg/client/pipe/JdbcPipe.java
+++ b/client/src/main/java/zingg/client/pipe/JdbcPipe.java
@@ -9,7 +9,10 @@ public class JdbcPipe extends Pipe{
 	public static final String TABLE="dbtable";
 	public static final String QUERY="query";
 	
-	
+	public JdbcPipe() {
+		setFormat(Format.JDBC);
+	}
+
 	public JdbcPipe(Pipe p) {
 		clone(p);
 	}

--- a/client/src/main/java/zingg/client/pipe/Pipe.java
+++ b/client/src/main/java/zingg/client/pipe/Pipe.java
@@ -60,12 +60,17 @@ public class Pipe implements Serializable{
 	public void setName(String name) {
 		this.name = name;		
 	}
-	
+
 	public Format getFormat() {
 		return format;
 	}
 	
 	@JsonValue
+	public void setFormat(String sinkType) {
+		this.format = Format.getFormat(sinkType); //Format.getPipeType(sinkType);
+		PipeFactory.register(name, this);
+	}
+
 	public void setFormat(Format sinkType) {
 		this.format = sinkType;
 		PipeFactory.register(name, this);
@@ -144,7 +149,7 @@ public class Pipe implements Serializable{
 
 	@Override
 	public String toString() {
-		return "Pipe [name=" + name + ", format=" + format + ", preprocessors="
+		return "Pipe [name=" + name + ", format=" + format.type() + ", preprocessors="
 				+ preprocessors + ", props=" + props + ", schema=" + schema + "]";
 	}
 	

--- a/client/src/main/java/zingg/client/pipe/PipeFactory.java
+++ b/client/src/main/java/zingg/client/pipe/PipeFactory.java
@@ -24,22 +24,22 @@ public class PipeFactory {
 	
 	private static final Pipe getPipe(Pipe p) {
 		try {
-			switch (p.format) {
-			case CSV:
-			case JSON:
-			case XLS:
-			case XLSX:
+			switch (p.format.type()) {
+			case "CSV":
+			case "JSON":
+			case "XLS":
+			case "XLSX":
 				return new FilePipe(p);
-			case CASSANDRA:
+			case "CASSANDRA":
 				return p;
-			case ELASTIC:
+			case "ELASTIC":
 				return p;
-			case JDBC:
+			case "JDBC":
 				return new JdbcPipe(p);
-			case INMEMORY:
+			case "INMEMORY":
 				return new InMemoryPipe(p);
 			default:
-				break;
+				return p;
 			}
 		}
 		catch (Exception e) {LOG.warn("given format not found, defaulting");}


### PR DESCRIPTION
* changes made for **Format** class to behave as close as possible earlier enum avatar.
* **PipeFactory** class seems redundant as of now. Particularly, its register() function. Therefore, its getPipe() functions has hardcoded format types. switch statement supports enum or constants only.