### PR TITLE
To fix Databrics UserWarning: DataFrame constructor is internal...

### DIFF
--- a/python/zingg/zingg.py
+++ b/python/zingg/zingg.py
@@ -51,9 +51,10 @@ class Zingg:
     def getUnsureMarkedRecordsStat(self):
         return self.client.getUnsureMarkedRecordsStat(self.getMarkedRecords())
     def getDfFromDs(self, data):
-        return DataFrame(data, sqlContext)
+        return DataFrame(data, spark)
     def getPandasDfFromDs(self, data):
-        return self.getDfFromDs(data).toPandas()
+        df = self.getDfFromDs(data)
+        return pd.DataFrame(df.collect(), columns=df.columns)
 
 class Arguments:
 


### PR DESCRIPTION
Used SparkSession object instead. SqlContext is deprecated. [Code link](https://spark.apache.org/docs/latest/api/python/_modules/pyspark/sql/dataframe.html)