### PR TITLE
Update Dependencies version

### DIFF
--- a/assembly/dependency-reduced-pom.xml
+++ b/assembly/dependency-reduced-pom.xml
@@ -45,7 +45,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>make-assembly</id>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -112,7 +112,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4.1</version>
+				<version>3.6.0</version>
 				<configuration>
 					<descriptors>
 						<descriptor>${project.basedir}/src/assembly/dist.xml</descriptor>

--- a/common/core/pom.xml
+++ b/common/core/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.14</version>
 		</dependency>	
 	</dependencies>
 </project>

--- a/spark/client/pom.xml
+++ b/spark/client/pom.xml
@@ -8,8 +8,8 @@
 	<artifactId>zingg-spark-client</artifactId>
 	<packaging>jar</packaging>
 	<properties>
-		<fasterxml.jackson.version>2.12.6</fasterxml.jackson.version>
-		<fasterxml.jackson.databind.version>2.12.6.1</fasterxml.jackson.databind.version>
+		<fasterxml.jackson.version>2.15.2</fasterxml.jackson.version>
+		<fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
+				<version>3.5.0</version>
 				<configuration>
 					<sourcepath>${basedir}/src/main/java/zingg/client</sourcepath>
 				</configuration>

--- a/spark/core/pom.xml
+++ b/spark/core/pom.xml
@@ -32,7 +32,7 @@
 	<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<version>3.2.2</version>
+				<version>4.8.0</version>
 				<executions>
 					<execution>
 						<id>scala-compile-first</id>


### PR DESCRIPTION
This PR is for the issue [765](https://github.com/zinggAI/zingg/issues/765).

java-11-openjdk-amd64 is working for both the spark and snowflake!!