### PR TITLE
Remove multiple registration of sim functions

### DIFF
--- a/spark/core/src/main/java/zingg/spark/core/similarity/SparkTransformer.java
+++ b/spark/core/src/main/java/zingg/spark/core/similarity/SparkTransformer.java
@@ -26,7 +26,18 @@ public class SparkTransformer extends SparkBaseTransformer {
 
 	 
     public void register(SparkSession spark) {
-    	spark.udf().register(getUid(), (UDF2) function, DataTypes.DoubleType);
+        if (!isUDFRegistered(spark, getUid())) {
+            spark.udf().register(getUid(), (UDF2) function, DataTypes.DoubleType);
+        } else {
+        }
+    }
+
+    private boolean isUDFRegistered(SparkSession spark, String udfName) {
+        try {
+            return spark.catalog().functionExists(udfName);
+        } catch (Exception e) {
+            return false; // UDF is not registered
+        }
     }
    
 

--- a/spark/core/src/main/java/zingg/spark/core/similarity/SparkTransformer.java
+++ b/spark/core/src/main/java/zingg/spark/core/similarity/SparkTransformer.java
@@ -10,6 +10,7 @@ import org.apache.spark.sql.SparkSession;
 
 public class SparkTransformer extends SparkBaseTransformer {
 	private static final long serialVersionUID = 1L;
+    private static boolean udfRegistered = false;
 
 	protected SparkSimFunction function;
 	
@@ -28,7 +29,9 @@ public class SparkTransformer extends SparkBaseTransformer {
     public void register(SparkSession spark) {
         if (!isUDFRegistered(spark, getUid())) {
             spark.udf().register(getUid(), (UDF2) function, DataTypes.DoubleType);
+            udfRegistered = true;
         } else {
+            udfRegistered = true;
         }
     }
 


### PR DESCRIPTION
This PR is for the issue [729](https://github.com/zinggAI/zingg/issues/729).

Tested with running the phases.
"
 [main] WARN org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry - The function affinegapsimilarityfunction replaced a previously registered function.
 [main] WARN org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry - The function jarowinklerfunction replaced a previously registered function.
 "
 not getting printed in the logs.