### PR TITLE
Update the Setter functions generated code in annotations

### DIFF
--- a/common/client/src/main/java/zingg/common/client/pipe/Pipe.java
+++ b/common/client/src/main/java/zingg/common/client/pipe/Pipe.java
@@ -55,7 +55,7 @@ public class Pipe<D,R,C> implements Serializable{ // St:StructType, Sv:SaveMode
 		return schema;
 	}
 
-
+	@PythonMethod
 	public void setSchema(String schema) {
 		this.schema = schema;
 	}
@@ -71,10 +71,12 @@ public class Pipe<D,R,C> implements Serializable{ // St:StructType, Sv:SaveMode
 		this.name = name;		
 	}
 	
+	@PythonMethod
 	public String getFormat() {
 		return format;
 	}
 	
+	@PythonMethod
 	@JsonValue
 	public void setFormat(String sinkType) {
 		this.format = sinkType;
@@ -90,6 +92,7 @@ public class Pipe<D,R,C> implements Serializable{ // St:StructType, Sv:SaveMode
 		return props;
 	}
 	
+	@PythonMethod
 	public void setProp(String k, String v) {
 		if (props == null) props = new HashMap<String, String>();
 		this.props.put(k, v);
@@ -134,6 +137,7 @@ public class Pipe<D,R,C> implements Serializable{ // St:StructType, Sv:SaveMode
 		this.dataset = ds;
 	}
 
+	@PythonMethod
 	@Override
 	public String toString() {
 		StringRedactor redactor = new StringRedactor();

--- a/common/py/src/main/java/zingg/common/py/processors/ProcessorContext.java
+++ b/common/py/src/main/java/zingg/common/py/processors/ProcessorContext.java
@@ -1,0 +1,22 @@
+package zingg.common.py.processors;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessorContext {
+    private static final ProcessorContext INSTANCE = new ProcessorContext();
+
+    private Map<String, List<String>> classMethodsMap = new HashMap<>();
+
+    private ProcessorContext() {
+    }
+
+    public static ProcessorContext getInstance() {
+        return INSTANCE;
+    }
+
+    public Map<String, List<String>> getClassMethodsMap() {
+        return classMethodsMap;
+    }
+}

--- a/common/py/src/main/java/zingg/common/py/processors/PythonClassProcessor.java
+++ b/common/py/src/main/java/zingg/common/py/processors/PythonClassProcessor.java
@@ -1,10 +1,14 @@
 package zingg.common.py.processors;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import javax.annotation.processing.*;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.type.TypeKind;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import javax.lang.model.element.*;
 import javax.lang.model.util.ElementFilter;
 
@@ -14,6 +18,12 @@ import zingg.common.py.annotations.*;
 public class PythonClassProcessor extends AbstractProcessor {
 
     private boolean importsAndDeclarationsGenerated = false;
+    private Map<String, List<String>> classMethodsMap = new HashMap<>();
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+    }
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
@@ -29,28 +39,40 @@ public class PythonClassProcessor extends AbstractProcessor {
         for (Element element : roundEnv.getElementsAnnotatedWith(PythonClass.class)) {
             if (element.getKind() == ElementKind.CLASS) {
                 TypeElement classElement = (TypeElement) element;
-                PackageElement packageElement =
-                    (PackageElement) classElement.getEnclosingElement();
+                PackageElement packageElement = (PackageElement) classElement.getEnclosingElement();
+                List<String> methodNames = new ArrayList<>();
+
                 System.out.println("class " + element.getSimpleName() + ":");
 
                 // __init__ method
                 System.out.println("    def __init__(self" +
                         generateConstructorParameters(classElement) + "):");
-                if (element.getSimpleName().contentEquals("pipe")) {
-                    generateClassInitializationCode(classElement);
+                if (element.getSimpleName().contentEquals("Pipe")) {
+                    generateClassInitializationCode(classElement, element);
                 }
                 for (VariableElement field : ElementFilter.fieldsIn(classElement.getEnclosedElements())) {
                     if (!field.getSimpleName().contentEquals("serialVersionUID")) {
-                        generateFieldInitializationCode(field);
+                        generateFieldInitializationCode(field, element);
                     }
                 }
+                for (ExecutableElement methodElement : ElementFilter.methodsIn(classElement.getEnclosedElements())) {
+                    if (methodElement.getAnnotation(PythonMethod.class) != null) {
+                        methodNames.add(methodElement.getSimpleName().toString());
+                    }
+                }
+                classMethodsMap.put(element.getSimpleName().toString(), methodNames);
             }
             System.out.println();   
-                // rest of generated class contents
+            // rest of generated class contents
         }
+        ProcessorContext processorContext = ProcessorContext.getInstance();
+        processorContext.getClassMethodsMap().putAll(classMethodsMap);
 
         return false;
+    }
 
+    Map<String, List<String>> getClassMethodsMap() {
+        return classMethodsMap;
     }
 
     private void generateImportsAndDeclarations() {
@@ -64,28 +86,41 @@ public class PythonClassProcessor extends AbstractProcessor {
         System.out.println();
     }
 
-    private void generateClassInitializationCode(TypeElement classElement) {
-        System.out.println("        self.pipe = getJVM().zingg.spark.client.pipe.SparkPipe()");
+    private void generateClassInitializationCode(TypeElement classElement, Element element) {
+        System.out.println("        self." + element.getSimpleName().toString().toLowerCase() + " = getJVM().zingg.spark.client.pipe.SparkPipe()");
     }
 
-    // private void generateFieldInitializationCode(VariableElement field, ExecutableElement methodElement, TypeElement classElement) {
-    private void generateFieldInitializationCode(VariableElement field) {
-        System.out.println("        self.pipe." + field.getSimpleName() + " = " + field.getSimpleName());
-        // String fieldName = field.getSimpleName().toString();
-        // String methodName = methodElement.getSimpleName().toString();
-        // System.out.println("        self." + fieldName + " = " + "getJVM()." +
-        //         classElement.getQualifiedName().toString() + "." + methodName + "(" + fieldName + ")");
+    private void generateFieldInitializationCode(VariableElement field, Element element) {
+        String fieldName = field.getSimpleName().toString();
+        String fieldAssignment = "self." + element.getSimpleName().toString().toLowerCase() + "." + fieldName + " = " + fieldName;
+    
+        if (!fieldName.startsWith("FORMAT_")) {
+            System.out.println("        " + fieldAssignment);
+        }
     }
 
     private String generateConstructorParameters(TypeElement classElement) {
         StringBuilder parameters = new StringBuilder();
-        for (VariableElement field : ElementFilter.fieldsIn(classElement.getEnclosedElements())) {
-            if (!field.getSimpleName().contentEquals("serialVersionUID")) {
-                parameters.append(", ");
-                parameters.append(field.getSimpleName());
-            }
+        List<VariableElement> fields = ElementFilter.fieldsIn(classElement.getEnclosedElements());
+
+        fields = fields.stream()
+                .filter(field -> !field.getSimpleName().contentEquals("serialVersionUID"))
+                .filter(this::isFieldForConstructor)
+                .collect(Collectors.toList());
+
+        for (VariableElement field : fields) {
+            parameters.append(", ");
+            parameters.append(field.getSimpleName());
         }
         return parameters.toString();
+    }
+
+    private boolean isFieldForConstructor(VariableElement field) {
+        String fieldName = field.getSimpleName().toString();
+    
+        return !fieldName.equals(fieldName.toUpperCase())
+                && !field.getModifiers().contains(Modifier.STATIC)
+                && !fieldName.startsWith("FORMAT_");
     }
     
 }


### PR DESCRIPTION
Now Generated setter function codes are matching with the written code:
```
 def setName(self, name):
        self.pipe.setName(name)
```
 
 Generated code:
```
import logging
from zingg.client import *
LOG = logging.getLogger("zingg.pipes")

JPipe = getJVM().zingg.spark.client.pipe.SparkPipe
FilePipe = getJVM().zingg.common.client.pipe.FilePipe
JStructType = getJVM().org.apache.spark.sql.types.StructType

class Pipe:
    def __init__(self, name, format, preprocessors, props, id, dataset, schema, mode):
        self.pipe = getJVM().zingg.spark.client.pipe.SparkPipe()
        self.pipe.name = name
        self.pipe.format = format
        self.pipe.preprocessors = preprocessors
        self.pipe.props = props
        self.pipe.id = id
        self.pipe.dataset = dataset
        self.pipe.schema = schema
        self.pipe.mode = mode

    def setSchema(self, schema):

        self.pipe.setSchema(schema)

    def getName(self):
        return getName

    def setName(self, name):

        self.pipe.setName(name)

    def getFormat(self):
        return getFormat

    def setFormat(self, sinkType):

        self.pipe.setFormat(sinkType)

    def setProp(self, k, v):

        self.pipe.setProp(k, v)

    def toString(self):
        return toString
```
 