### PR TITLE
Update Annotations to generate code

### DIFF
--- a/common/py/src/main/java/zingg/common/py/processors/PythonClassProcessor.java
+++ b/common/py/src/main/java/zingg/common/py/processors/PythonClassProcessor.java
@@ -47,14 +47,14 @@ public class PythonClassProcessor extends AbstractProcessor {
                 // __init__ method
                 System.out.println("    def __init__(self" +
                         generateConstructorParameters(classElement) + "):");
-                if (element.getSimpleName().contentEquals("Pipe")) {
-                    generateClassInitializationCode(classElement, element);
-                }
-                for (VariableElement field : ElementFilter.fieldsIn(classElement.getEnclosedElements())) {
-                    if (!field.getSimpleName().contentEquals("serialVersionUID")) {
-                        generateFieldInitializationCode(field, element);
-                    }
-                }
+                generateClassInitializationCode(classElement, element);
+
+                // for (VariableElement field : ElementFilter.fieldsIn(classElement.getEnclosedElements())) {
+                //     if (!field.getSimpleName().contentEquals("serialVersionUID")) {
+                //         generateFieldInitializationCode(field, element);
+                //     }
+                // }
+
                 for (ExecutableElement methodElement : ElementFilter.methodsIn(classElement.getEnclosedElements())) {
                     if (methodElement.getAnnotation(PythonMethod.class) != null) {
                         methodNames.add(methodElement.getSimpleName().toString());
@@ -87,17 +87,19 @@ public class PythonClassProcessor extends AbstractProcessor {
     }
 
     private void generateClassInitializationCode(TypeElement classElement, Element element) {
-        System.out.println("        self." + element.getSimpleName().toString().toLowerCase() + " = getJVM().zingg.spark.client.pipe.SparkPipe()");
-    }
-
-    private void generateFieldInitializationCode(VariableElement field, Element element) {
-        String fieldName = field.getSimpleName().toString();
-        String fieldAssignment = "self." + element.getSimpleName().toString().toLowerCase() + "." + fieldName + " = " + fieldName;
-    
-        if (!fieldName.startsWith("FORMAT_")) {
-            System.out.println("        " + fieldAssignment);
+        if (element.getSimpleName().contentEquals("Pipe")) {
+            System.out.println("        self." + element.getSimpleName().toString().toLowerCase() + " = getJVM().zingg.spark.client.pipe.SparkPipe()");
         }
     }
+
+    // private void generateFieldInitializationCode(VariableElement field, Element element) {
+    //     String fieldName = field.getSimpleName().toString();
+    //     String fieldAssignment = "self." + element.getSimpleName().toString().toLowerCase() + "." + fieldName + " = " + fieldName;
+    
+    //     if (!fieldName.startsWith("FORMAT_")) {
+    //         System.out.println("        " + fieldAssignment);
+    //     }
+    // }
 
     private String generateConstructorParameters(TypeElement classElement) {
         StringBuilder parameters = new StringBuilder();

--- a/common/py/src/main/java/zingg/common/py/processors/PythonMethodProcessor.java
+++ b/common/py/src/main/java/zingg/common/py/processors/PythonMethodProcessor.java
@@ -7,7 +7,7 @@ import javax.annotation.processing.*;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeKind;
 import java.util.Set;
-import java.util.logging.Logger;
+// import java.util.logging.Logger;
 
 import javax.lang.model.element.*;
 import zingg.common.py.annotations.*;
@@ -38,7 +38,8 @@ public class PythonMethodProcessor extends AbstractProcessor {
                     if (methodNames.contains(methodElement.getSimpleName().toString())) {
                         // LOG.info("Generating Python method for: " + methodElement.getSimpleName());
                         System.out.println("    def " + methodElement.getSimpleName() + "(self" +
-                                generateMethodSignature(methodElement) + "):\n        " + generateMethodReturn(methodElement));
+                                generateMethodSignature(methodElement) + "):");
+                        generateMethodReturn(methodElement);
                         generateFieldAssignment(methodElement);
                     }
                 }
@@ -64,14 +65,15 @@ public class PythonMethodProcessor extends AbstractProcessor {
         return parameters.toString();
     }
 
-    private String generateMethodReturn(ExecutableElement methodElement) {
+    private void generateMethodReturn(ExecutableElement methodElement) {
         TypeMirror returnType = methodElement.getReturnType();
         if (returnType.getKind() == TypeKind.VOID) {
-            return "";
+            return;
         } else {
             String returnTypeString = resolveType(returnType);
-            String variableName = methodElement.getSimpleName().toString();
-            return "return " + variableName;
+            String methodName = methodElement.getSimpleName().toString();
+            String className = methodElement.getEnclosingElement().getSimpleName().toString();
+            System.out.println("        return self." + className.toLowerCase() + "." + methodName + "()");
         }
     }
 


### PR DESCRIPTION
Now generated code is closer to the written py code.
```
import logging
from zingg.client import *
LOG = logging.getLogger("zingg.pipes")

JPipe = getJVM().zingg.spark.client.pipe.SparkPipe
FilePipe = getJVM().zingg.common.client.pipe.FilePipe
JStructType = getJVM().org.apache.spark.sql.types.StructType

class Pipe:
    def __init__(self, name, format, preprocessors, props, id, dataset, schema, mode):
        self.pipe = getJVM().zingg.spark.client.pipe.SparkPipe()

    def setSchema(self, schema):
        self.pipe.setSchema(schema)

    def getName(self):
        return self.pipe.getName()

    def setName(self, name):
        self.pipe.setName(name)

    def getFormat(self):
        return self.pipe.getFormat()

    def setFormat(self, sinkType):
        self.pipe.setFormat(sinkType)

    def setProp(self, k, v):
        self.pipe.setProp(k, v)

    def toString(self):
        return self.pipe.toString()
```