### PR TITLE
Add/Remove dependencies for TestSparkFrame and TestSparkExecutors

### DIFF
--- a/spark/client/pom.xml
+++ b/spark/client/pom.xml
@@ -28,12 +28,12 @@
 			<version>${fasterxml.jackson.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
+		<!-- <dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${fasterxml.jackson.databind.version}</version>
 			<scope>provided</scope>
-		</dependency>
+		</dependency> -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>

--- a/spark/core/pom.xml
+++ b/spark/core/pom.xml
@@ -50,6 +50,11 @@
 			<version>5.8.1</version>
 			<scope>test</scope>
 		</dependency>	
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
 </dependencies>
 <build>
 		


### PR DESCRIPTION
This PR is for the issue [zingg.client.TestSparkFrame junit error in enterprise branch](https://github.com/zinggAI/zingg/issues/779)

`mvn clean compile package`
all the junits are running successfully.