### PR TITLE
 Fix mvn build creating unresolved ${project.parent.basedir} directories

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -46,7 +46,7 @@
                 <outputDirectory>${basedir}/target/classes/python/phases</outputDirectory>
                 <resources>
                     <resource>
-                        <directory>${project.parent.basedir}/python/phases</directory>
+                        <directory>${project.basedir}/../python/phases</directory>
                     </resource>
                 </resources>
             </configuration>


### PR DESCRIPTION
### Summary
Fixes Maven build issue where unresolved `${project.parent.basedir}` caused incorrect directory creation.

### Changes
- Replaced usage of `${project.parent.basedir}` with a safer module-relative path.

### Testing
- Ran `mvn clean install -DskipTests`
- Verified no unresolved directories are created.

Fixes #767
