### PR TITLE
Updated the calendly link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Want to commit code? Please check the [contributing documentation.](https://docs
 
 ## Book Office Hours
 
-If you want to schedule a 30-min call with our team to help you understand if Zingg is the right technology for your problem, please book a slot [here](https://calendly.com/sonalgoyal/30min). For troubleshooting and Zingg issues, please report the problem as an issue on github. 
+If you want to schedule a call with our team to help you understand if Zingg is the right technology for your problem, please book a slot [here](https://calendly.com/sonalgoyal/). For troubleshooting and Zingg issues, please report the problem as an issue on github. 
 
 ## Asking questions on running Zingg
 


### PR DESCRIPTION
I have updated the expired calendly link to book meeting slot with the one provided on the website.