### PR TITLE
Resolving Dependency Issue

### DIFF
--- a/docs/stepbystep/installation/compiling-from-source.md
+++ b/docs/stepbystep/installation/compiling-from-source.md
@@ -12,5 +12,4 @@ If you need to compile the latest code or build for a different Spark version, y
 * Install **Apache Spark (version spark-3.5.0-bin-hadoop3)**
 * Set `SPARK_HOME` as path to location of Apache Spark
 * Set `SPARK_MASTER` as **local[*]**
-
-* Run the following: `mvn initialize` and then `mvn clean compile package`
+* Run the following: `mvn clean install -U` -> `mvn initialize` -> `mvn clean compile package`


### PR DESCRIPTION
I have added the following command in docs to run before initializing mvn and compiling the source code.

mvn clean install -U

mvn install takes the compiled JARs of every module (including the missing zingg-common-client) and places them in your local ~/.m2/repository. Once they are there, the "core" module will stop looking at the Central Repository (internet) and find them on your disk.