### PR TITLE
tar compression

### DIFF
--- a/assembly/src/assembly/dist.xml
+++ b/assembly/src/assembly/dist.xml
@@ -56,14 +56,14 @@
       <directory>${project.parent.basedir}/examples</directory>
       <outputDirectory>examples</outputDirectory>
       <includes>
-        <include>**/*</include>
+        <include>febrl120k/**/*</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/models</directory>
       <outputDirectory>models</outputDirectory>
       <includes>
-        <include>**/*</include>
+        <include>101/**/*</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
I have removed all examples and models from the release tar expcept febrl 120k and its model.
here are the results. closes: https://github.com/zinggAI/zingg/issues/1175
before:
<img width="441" height="17" alt="Screenshot 2026-01-30 at 17 28 35" src="https://github.com/user-attachments/assets/f4683b43-e8cc-494c-8a4f-da45ac88c087" />
after:
<img width="444" height="23" alt="Screenshot 2026-01-30 at 17 28 46" src="https://github.com/user-attachments/assets/502019f3-053d-44cc-ab09-fd7a921a2fb3" />
