### PR TITLE
release tar size reduction

### DIFF
--- a/assembly/src/assembly/dist.xml
+++ b/assembly/src/assembly/dist.xml
@@ -44,6 +44,18 @@
       <includes>
         <include>**/*</include>
       </includes>
+      <excludes>
+        <exclude>venv/**</exclude>
+        <exclude>.venv/**</exclude>
+        <exclude>**/__pycache__/**</exclude>
+        <exclude>**/*.pyc</exclude>
+        <exclude>**/*.pyo</exclude>
+        <exclude>build/**</exclude>
+        <exclude>dist/**</exclude>
+        <exclude>*.egg-info/**</exclude>
+        <exclude>.pytest_cache/**</exclude>
+        <exclude>.tox/**</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/assets</directory>
@@ -56,14 +68,17 @@
       <directory>${project.parent.basedir}/examples</directory>
       <outputDirectory>examples</outputDirectory>
       <includes>
-        <include>**/*</include>
+        <include>febrl/**</include>
+        <include>febrl120k/**</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/models</directory>
       <outputDirectory>models</outputDirectory>
       <includes>
-        <include>**/*</include>
+        <include>100/**</include>
+        <include>101/**</include>
+        <include>102/**</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
I have removed examples and models except febrl, also the python tmp files like venv, etc.
closes: https://github.com/zinggAI/zingg/issues/1175

before:

<img width="441" height="17" alt="Image" src="https://github.com/user-attachments/assets/e9490636-186c-4a40-8db3-8676d819df7b" />

after:

<img width="290" height="32" alt="Screenshot 2026-01-31 at 02 28 03" src="https://github.com/user-attachments/assets/2efc75f3-ed7d-444a-8247-389155c992ca" />
