### PR TITLE
recursively cleaning the junit_integration_spark dir

### DIFF
--- a/spark/core/src/test/java/zingg/spark/core/util/SparkCleanUpUtil.java
+++ b/spark/core/src/test/java/zingg/spark/core/util/SparkCleanUpUtil.java
@@ -1,13 +1,22 @@
 package zingg.spark.core.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.spark.sql.SparkSession;
 
 import zingg.common.core.util.ICleanUpUtil;
 import zingg.common.core.util.TestType;
 
 public class SparkCleanUpUtil implements ICleanUpUtil<SparkSession> {
+    public static final Log LOG = LogFactory.getLog(SparkCleanUpUtil.class);
     private static final String JUNIT_DIR = "/tmp/junit_integration_spark";
     private static final String SINGLE_TEST_DIR = "single";
     private static final String COMPOUND_TEST_DIR = "compound";
@@ -17,17 +26,62 @@ public class SparkCleanUpUtil implements ICleanUpUtil<SparkSession> {
 
     }
 
+    public static void cleanUpBeforeTest() {
+        cleanUp(JUNIT_DIR);
+    }
+
     @Override
     public boolean performCleanup(SparkSession session, TestType testType, String modelId) {
         try {
             String suffix = TestType.SINGLE.equals(testType) ? SINGLE_TEST_DIR : COMPOUND_TEST_DIR;
-            File dir = new File(JUNIT_DIR + "/" + suffix);
-            /* force delete since we want to make sure
-            * dir gets deleted even if it is non-empty*/
-            dir.delete();
+            String path = JUNIT_DIR + "/" + suffix;
+            File dir = new File(path);
+
+            if (!dir.exists()) {
+                LOG.info("Cleanup not needed. Directory does not exist: " + path);
+                return true;
+            }
+
+            LOG.info("Starting cleanup for directory: " + path);
+            deleteRecursively(dir.toPath());
+            LOG.info("Successfully cleaned up directory: " + path);
             return true;
         } catch (Exception exception) {
+            String suffix = TestType.SINGLE.equals(testType) ? SINGLE_TEST_DIR : COMPOUND_TEST_DIR;
+            String path = JUNIT_DIR + "/" + suffix;
+            LOG.error("Failed to clean up directory: " + path, exception);
             return false;
+        }
+    }
+
+    private static void cleanUp(String directoryPath) {
+        File dir = new File(directoryPath);
+        if (dir.exists()) {
+            try {
+                LOG.info("Starting cleanup for directory: " + directoryPath);
+                deleteRecursively(dir.toPath());
+                LOG.info("Successfully cleaned up directory: " + directoryPath);
+            } catch (IOException e) {
+                LOG.error("Failed to clean up directory: " + directoryPath, e);
+            }
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (Files.exists(path)) {
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
         }
     }
 


### PR DESCRIPTION
closes https://github.com/zinggAI/zinggEnterprise/issues/1169
before:
<img width="569" height="79" alt="Screenshot 2026-02-12 at 13 00 51" src="https://github.com/user-attachments/assets/546bd88b-4f2c-4c5e-a7a4-60512c9d6f1b" />
after
<img width="778" height="175" alt="Screenshot 2026-02-12 at 13 01 25" src="https://github.com/user-attachments/assets/eb743cb0-55b7-460b-8a9b-ae0ec99a8e6a" />
we can see cleanup was performed after running mvn install