### PR TITLE
Remove Arguments.createArgumentsFromJSON and tests

### DIFF
--- a/docs/pythonOss/markdown/_autosummary/zingg.client.Arguments.md
+++ b/docs/pythonOss/markdown/_autosummary/zingg.client.Arguments.md
@@ -17,9 +17,6 @@ This class helps supply match arguments to Zingg. There are 3 basic steps in any
 
 | [`__init__`](#zingg.client.Arguments.__init__)                                               |                                                                                                                                                                                                                                                                                                             |
 |----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `copyArgs`                                                                                   |                                                                                                                                                                                                                                                                                                             |
-| [`createArgumentsFromJSON`](#zingg.client.Arguments.createArgumentsFromJSON)                 | Method to create an object of this class from the JSON file and phase parameter value.                                                                                                                                                                                                                      |
-| `createArgumentsFromJSONString`                                                              |                                                                                                                                                                                                                                                                                                             |
 | [`getArgs`](#zingg.client.Arguments.getArgs)                                                 | Method to get pointer address of this class                                                                                                                                                                                                                                                                 |
 | `getModelId`                                                                                 |                                                                                                                                                                                                                                                                                                             |
 | `getZinggBaseModelDir`                                                                       |                                                                                                                                                                                                                                                                                                             |
@@ -38,22 +35,8 @@ This class helps supply match arguments to Zingg. There are 3 basic steps in any
 | [`setStopWordsCutoff`](#zingg.client.Arguments.setStopWordsCutoff)                           | Method to set stopWordsCutoff parameter value By default, Zingg extracts 10% of the high frequency unique words from a dataset.                                                                                                                                                                             |
 | [`setTrainingSamples`](#zingg.client.Arguments.setTrainingSamples)                           | Method to set existing training samples to be matched.                                                                                                                                                                                                                                                      |
 | [`setZinggDir`](#zingg.client.Arguments.setZinggDir)                                         | Method to set the location for Zingg to save its internal computations and models.                                                                                                                                                                                                                          |
-| [`writeArgumentsToJSON`](#zingg.client.Arguments.writeArgumentsToJSON)                       | Method to write JSON file from the object of this class                                                                                                                                                                                                                                                     |
-| [`writeArgumentsToJSONString`](#zingg.client.Arguments.writeArgumentsToJSONString)           | Method to create an object of this class from the JSON file and phase parameter value.                                                                                                                                                                                                                      |
-
 #### \_\_init_\_()
 
-#### *static* createArgumentsFromJSON(fileName, phase)
-
-Method to create an object of this class from the JSON file and phase parameter value.
-
-* **Parameters:**
-  * **fileName** (*String*) – The CONF parameter value of ClientOption object
-  * **phase** (*String*) – The PHASE parameter value of ClientOption object
-* **Returns:**
-  The pointer containing address of the this class object
-* **Return type:**
-  pointer([Arguments](#zingg.client.Arguments))
 
 #### getArgs()
 
@@ -159,22 +142,3 @@ Method to set the location for Zingg to save its internal computations and model
 
 * **Parameters:**
   **f** (*String*) – Zingg directory name of the models
-
-#### writeArgumentsToJSON(fileName)
-
-Method to write JSON file from the object of this class
-
-* **Parameters:**
-  **fileName** (*String*) – The CONF parameter value of ClientOption object or file address of json file
-
-#### writeArgumentsToJSONString()
-
-Method to create an object of this class from the JSON file and phase parameter value.
-
-* **Parameters:**
-  * **fileName** (*String*) – The CONF parameter value of ClientOption object
-  * **phase** (*String*) – The PHASE parameter value of ClientOption object
-* **Returns:**
-  The pointer containing address of the this class object
-* **Return type:**
-  pointer([Arguments](#zingg.client.Arguments))

--- a/python/docs/_autosummary/zingg.client.Arguments.rst
+++ b/python/docs/_autosummary/zingg.client.Arguments.rst
@@ -17,9 +17,6 @@
       :nosignatures:
    
       ~Arguments.__init__
-      ~Arguments.copyArgs
-      ~Arguments.createArgumentsFromJSON
-      ~Arguments.createArgumentsFromJSONString
       ~Arguments.getArgs
       ~Arguments.getModelId
       ~Arguments.getZinggBaseModelDir
@@ -38,8 +35,6 @@
       ~Arguments.setStopWordsCutoff
       ~Arguments.setTrainingSamples
       ~Arguments.setZinggDir
-      ~Arguments.writeArgumentsToJSON
-      ~Arguments.writeArgumentsToJSONString
    
    
 

--- a/python/zingg/client.py
+++ b/python/zingg/client.py
@@ -688,22 +688,6 @@ class Arguments:
         """
         self.args.setColumn(column)
 
-    @staticmethod
-    def createArgumentsFromJSON(fileName, phase):
-        """Method to create an object of this class from the JSON file and phase parameter value.
-
-        :param fileName: The CONF parameter value of ClientOption object
-        :type fileName: String
-        :param phase: The PHASE parameter value of ClientOption object
-        :type phase: String
-        :return: The pointer containing address of the this class object
-        :rtype: pointer(Arguments)
-        """
-        obj = Arguments()
-        obj.args = getJVM().zingg.common.client.arguments.ArgumentServiceImpl().loadArguments(fileName)
-        return obj
-
-
 class ClientOptions:
     """Class that contains Client options for Zingg object
     :param phase: trainMatch, train, match, link, findAndLabel, findTrainingData, recommend etc

--- a/test/testFebrl/testArgs.py
+++ b/test/testFebrl/testArgs.py
@@ -473,16 +473,6 @@ class ArgumentsTest(TestCase):
         actual_stopWordsCutoff = java_args.getStopWordsCutoff()
         
         self.assertEqual(actual_stopWordsCutoff, stopWordsCutoff)
-    
-    def test_createArgumentsFromJSON(self):
-        fileName = "examples/febrl/config.json"
-        phase = "label"
-
-        obj = args.createArgumentsFromJSON(fileName, phase)
-        print("JSON file content:", obj)
-        print("Phase:", phase)
-
-        self.assertIsInstance(obj, Arguments)
 
 class TestClientOptions(TestCase):
 


### PR DESCRIPTION
Remove the static createArgumentsFromJSON method from the Arguments class and clean up related references. The method implementation was deleted from python/zingg/client.py, docs references were removed from docs/pythonOss/markdown/_autosummary/zingg.client.Arguments.md and python/docs/_autosummary/zingg.client.Arguments.rst, and the corresponding unit test (test_createArgumentsFromJSON) was removed from test/testFebrl/testArgs.py. fixes #1312 