### PR TITLE
Labeller Improvisations 

### DIFF
--- a/common/client/src/main/java/zingg/common/client/IZinggModelInfo.java
+++ b/common/client/src/main/java/zingg/common/client/IZinggModelInfo.java
@@ -4,7 +4,7 @@ package zingg.common.client;
 public interface IZinggModelInfo<S,D,R,C> {
     ZFrame<D,R,C>  getMarkedRecords();
 
-    ZFrame<D,R,C>  getUnmarkedRecords();
+    ZFrame<D,R,C>  getUnmarkedRecords() throws ZinggClientException;
 
     Long getMarkedRecordsStat(ZFrame<D, R, C> markedRecords, long value);
 

--- a/common/core/src/main/java/zingg/common/core/executor/Labeller.java
+++ b/common/core/src/main/java/zingg/common/core/executor/Labeller.java
@@ -27,13 +27,16 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 	protected ITrainingDataModel<S, D, R, C> trainingDataModel;
 	protected ILabelDataViewHelper<S, D, R, C> labelDataViewHelper;
 	protected LabellerUtil<D, R, C> labellerUtil;
-	
+	protected CLIReader cliReader;
+
+	// Initializing dependency classes in constructor
 	public Labeller() {
 		setZinggOption(ZinggOptions.LABEL);
 		this.trainingDataModel = new TrainingDataModel<S, D, R, C, T>(getContext(), getClientOptions());
 		this.labelDataViewHelper = new LabelDataViewHelper<S,D,R,C,T>(getContext(), getClientOptions());
 		this.labelDataViewHelper.initVerticalDisplayUtility(getDfObjectUtil());
 		this.labellerUtil = new LabellerUtil<D, R, C>();
+		this.cliReader = new CLIReader();
 	}
 
 	public void execute() throws ZinggClientException {
@@ -53,7 +56,6 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 			throw new ZinggClientException("Error in labelling phase ", e);
 		}
 	}
-
 
 	public ZFrame<D,R,C> getUnmarkedRecords() throws ZinggClientException {
 		ZFrame<D,R,C> unmarkedRecords = null;
@@ -88,63 +90,70 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 					);
 
 			lines = lines.cache();
-//			List<C> displayCols = getLabelDataViewHelper().getDisplayColumns(lines, args);
-			ZidAndFieldDefSelector zidAndFieldDefSelector = new ZidAndFieldDefSelector(args.getFieldDefinition(), false, args.getShowConcise());
+			//List<C> displayCols = getLabelDataViewHelper().getDisplayColumns(lines, args);
+
 			//have to introduce as snowframe can not handle row.getAs with column
 			//name and row and lines are out of order for the code to work properly
 			//snow getAsString expects row to have same struc as dataframe which is 
 			//not happening
-			ZFrame<D,R,C> clusterIdZFrame = getLabelDataViewHelper().getClusterIdsFrame(lines);
-			List<R>  clusterIDs = getLabelDataViewHelper().getClusterIds(clusterIdZFrame);
-			try {
-				double score;
-				double prediction;
-				ZFrame<D,R,C>  updatedRecords = null;
-				int selectedOption = -1;
-				String msg1, msg2;
-				int totalPairs = clusterIDs.size();
 
-				for (int index = 0; index < totalPairs; index++) {
-					ZFrame<D,R,C>  currentPair = getLabelDataViewHelper().getCurrentPair(lines, index, clusterIDs, clusterIdZFrame);
-
-					score = getLabelDataViewHelper().getScore(currentPair);
-					prediction = getLabelDataViewHelper().getPrediction(currentPair);
-
-					msg1 = getLabelDataViewHelper().getMsg1(index, totalPairs);
-					msg2 = getLabelDataViewHelper().getMsg2(prediction, score);
-					//String msgHeader = msg1 + msg2;
-
-//					selectedOption = displayRecordsAndGetUserInput(getDSUtil().select(currentPair, displayCols), msg1, msg2);
-					selectedOption = displayRecordsAndGetUserInput(currentPair.select(zidAndFieldDefSelector.getCols()), msg1, msg2);
-					getTrainingDataModel().updateLabellerStat(selectedOption, INCREMENT);
-					getLabelDataViewHelper().printMarkedRecordsStat(
-							getTrainingDataModel().getPositivePairsCount(),
-							getTrainingDataModel().getNegativePairsCount(),
-							getTrainingDataModel().getNotSurePairsCount(),
-							getTrainingDataModel().getTotalCount()
-							);
-					if (selectedOption == QUIT_LABELING) {
-						LOG.info("User has quit in the middle. Updating the records.");
-						break;
-					}
-					updatedRecords = getTrainingDataModel().updateRecords(selectedOption, currentPair, updatedRecords);
-				}
-				LOG.warn("Processing finished.");
-				return updatedRecords;
-			} catch (Exception e) {
-				LOG.warn("Labelling error has occured " + e.getMessage());
-				throw new ZinggClientException("An error has occured while Labelling.", e);
-			}
+			// Breaking down a bigger implementation into smaller understandable segments
+            return getUpdatedRecords(lines);
 		} else {
 			LOG.info("It seems there are no unmarked records at this moment. Please run findTrainingData job to build some pairs to be labelled and then run this labeler.");
 			return null;
 		}
 	}
 
+	private ZFrame<D,R,C> getUpdatedRecords(ZFrame<D,R,C>  lines) throws ZinggClientException {
+		ZFrame<D,R,C> clusterIdZFrame = getLabelDataViewHelper().getClusterIdsFrame(lines);
+		List<R>  clusterIDs = getLabelDataViewHelper().getClusterIds(clusterIdZFrame);
+		ZidAndFieldDefSelector zidAndFieldDefSelector = new ZidAndFieldDefSelector(args.getFieldDefinition(), false, args.getShowConcise());
+		try {
+			double score;
+			double prediction;
+			ZFrame<D,R,C>  updatedRecords = null;
+			int selectedOption = -1;
+			String msg1, msg2;
+			int totalPairs = clusterIDs.size();
+
+			for (int index = 0; index < totalPairs; index++) {
+				ZFrame<D,R,C>  currentPair = getLabelDataViewHelper().getCurrentPair(lines, index, clusterIDs, clusterIdZFrame);
+
+				score = getLabelDataViewHelper().getScore(currentPair);
+				prediction = getLabelDataViewHelper().getPrediction(currentPair);
+
+				msg1 = getLabelDataViewHelper().getMsg1(index, totalPairs);
+				msg2 = getLabelDataViewHelper().getMsg2(prediction, score);
+				// String msgHeader = msg1 + msg2;
+
+				// selectedOption = displayRecordsAndGetUserInput(getDSUtil().select(currentPair, displayCols), msg1, msg2);
+				selectedOption = displayRecordsAndGetUserInput(currentPair.select(zidAndFieldDefSelector.getCols()), msg1, msg2);
+				getTrainingDataModel().updateLabellerStat(selectedOption, INCREMENT);
+				getLabelDataViewHelper().printMarkedRecordsStat(
+						trainingDataModel.getPositivePairsCount(),
+						trainingDataModel.getNegativePairsCount(),
+						trainingDataModel.getNotSurePairsCount(),
+						trainingDataModel.getTotalCount()
+				);
+				if (selectedOption == QUIT_LABELING) {
+					LOG.info("User has quit in the middle. Updating the records.");
+					break;
+				}
+				updatedRecords = getTrainingDataModel().updateRecords(selectedOption, currentPair, updatedRecords);
+			}
+			LOG.warn("Processing finished.");
+			return updatedRecords;
+		} catch (Exception | ZinggClientException e) {
+			LOG.warn("Labelling error has occured " + e.getMessage());
+			throw new ZinggClientException("An error has occured while Labelling.", e);
+		}
+    }
+
 	
 	protected int displayRecordsAndGetUserInput(ZFrame<D,R,C> records, String preMessage, String postMessage) throws ZinggClientException {
 		getLabelDataViewHelper().displayRecords(records, preMessage, postMessage);
-        return CLIReader.readCliInput();
+        return cliReader.readCliInput("[0129]");
 	}
 
 	@Override

--- a/common/core/src/main/java/zingg/common/core/executor/Labeller.java
+++ b/common/core/src/main/java/zingg/common/core/executor/Labeller.java
@@ -1,7 +1,6 @@
 package zingg.common.core.executor;
 
 import java.util.List;
-import java.util.Scanner;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -15,6 +14,7 @@ import zingg.common.client.options.ZinggOptions;
 import zingg.common.client.util.ColName;
 import zingg.common.client.util.DFObjectUtil;
 import zingg.common.core.preprocess.IPreprocessors;
+import zingg.common.core.util.CLIReader;
 import zingg.common.core.util.LabellerUtil;
 
 public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implements IPreprocessors<S,D,R,C,T> {
@@ -26,14 +26,18 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 	public static final Log LOG = LogFactory.getLog(Labeller.class);
 	protected ITrainingDataModel<S, D, R, C> trainingDataModel;
 	protected ILabelDataViewHelper<S, D, R, C> labelDataViewHelper;
+	protected LabellerUtil<D, R, C> labellerUtil;
 	
 	public Labeller() {
 		setZinggOption(ZinggOptions.LABEL);
+		this.trainingDataModel = new TrainingDataModel<S, D, R, C, T>(getContext(), getClientOptions());
+		this.labelDataViewHelper = new LabelDataViewHelper<S,D,R,C,T>(getContext(), getClientOptions());
+		this.labelDataViewHelper.initVerticalDisplayUtility(getDfObjectUtil());
+		this.labellerUtil = new LabellerUtil<D, R, C>();
 	}
 
 	public void execute() throws ZinggClientException {
 		try {
-			LabellerUtil<D, R, C> labellerUtil = new LabellerUtil<D, R, C>();
 			LOG.info("Reading inputs for labelling phase ...");
 			getTrainingDataModel().setMarkedRecordsStat(getMarkedRecords());
 			ZFrame<D,R,C>  unmarkedRecords = getUnmarkedRecords();
@@ -50,29 +54,25 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 		}
 	}
 
-	
-	public ZFrame<D,R,C> getUnmarkedRecords() {
+
+	public ZFrame<D,R,C> getUnmarkedRecords() throws ZinggClientException {
 		ZFrame<D,R,C> unmarkedRecords = null;
 		ZFrame<D,R,C> markedRecords = null;
 		try {
 			unmarkedRecords = getPipeUtil().read(false, false, getModelHelper().getTrainingDataUnmarkedPipe(args));
 			try {
 				markedRecords = getPipeUtil().read(false, false, getModelHelper().getTrainingDataMarkedPipe(args));
-			} catch (Exception e) {
+			} catch (Exception | ZinggClientException e) {
 				LOG.warn("No record has been marked yet");
-			} catch (ZinggClientException zce) {
-					LOG.warn("No record has been marked yet");
-			}			
-			if (markedRecords != null ) {
+			}
+            if (markedRecords != null ) {
 				unmarkedRecords = unmarkedRecords.join(markedRecords,ColName.CLUSTER_COLUMN, false,
 						"left_anti");
 				getTrainingDataModel().setMarkedRecordsStat(markedRecords);
-			} 
-		} catch (Exception e) {
+			}
+		} catch (Exception | ZinggClientException e) {
 			LOG.warn("No unmarked record for labelling");
-		} catch (ZinggClientException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
+			throw new ZinggClientException(e);
 		}
 		return unmarkedRecords;
 	}
@@ -144,30 +144,11 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 	
 	protected int displayRecordsAndGetUserInput(ZFrame<D,R,C> records, String preMessage, String postMessage) throws ZinggClientException {
 		getLabelDataViewHelper().displayRecords(records, preMessage, postMessage);
-		int selection = readCliInput();
-		return selection;
-	}
-
-
-	int readCliInput() {
-		Scanner sc = new Scanner(System.in);
-
-		while (!sc.hasNext("[0129]")) {
-			sc.next();
-			System.out.println("Nope, please enter one of the allowed options!");
-		}
-		String word = sc.next();
-		int selection = Integer.parseInt(word);
-		// sc.close();
-
-		return selection;
+        return CLIReader.readCliInput();
 	}
 
 	@Override
-	public ITrainingDataModel<S, D, R, C> getTrainingDataModel() {	
-		if (trainingDataModel==null) {
-			this.trainingDataModel = new TrainingDataModel<S, D, R, C, T>(getContext(), getClientOptions());
-		}
+	public ITrainingDataModel<S, D, R, C> getTrainingDataModel() {
 		return trainingDataModel;
     }
 
@@ -177,10 +158,6 @@ public abstract class Labeller<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implement
 
 	
 	public ILabelDataViewHelper<S, D, R, C> getLabelDataViewHelper() {
-		if(labelDataViewHelper==null) {
-			labelDataViewHelper = new LabelDataViewHelper<S,D,R,C,T>(getContext(), getClientOptions());
-			labelDataViewHelper.initVerticalDisplayUtility(getDfObjectUtil());
-		}
     	return labelDataViewHelper;
     }
 

--- a/common/core/src/main/java/zingg/common/core/executor/ZinggBase.java
+++ b/common/core/src/main/java/zingg/common/core/executor/ZinggBase.java
@@ -100,7 +100,7 @@ public abstract class ZinggBase<S,D, R, C, T> extends ZinggBaseCommon<S, D, R, C
         }
 	}
 
-	public ZFrame<D,R,C> getUnmarkedRecords(){
+	public ZFrame<D,R,C> getUnmarkedRecords() throws ZinggClientException {
         try{
             ZFrame<D,R,C> unmarkedRecords = null;
             ZFrame<D,R,C> markedRecords = null;

--- a/common/core/src/main/java/zingg/common/core/util/CLIReader.java
+++ b/common/core/src/main/java/zingg/common/core/util/CLIReader.java
@@ -2,20 +2,25 @@ package zingg.common.core.util;
 
 import java.util.Scanner;
 
+/*
+* Generic Class CLIReader for reading user inputs.
+* Independent of labelling logic
+* */
+
 public class CLIReader {
-    private static final String userInputRegex = "[0129]";
+    private Scanner scanner;
 
-    public static int readCliInput() {
-        Scanner sc = new Scanner(System.in);
+    public CLIReader() {
+        this.scanner = new Scanner(System.in);
+    }
 
-        while (!sc.hasNext(userInputRegex)) {
-            sc.next();
+    public int readCliInput(String userInputRegex) {
+        while (!scanner.hasNext(userInputRegex)) {
+            scanner.next();
             System.out.println("Nope, please enter one of the allowed options!");
         }
-        String word = sc.next();
-        int selection = Integer.parseInt(word);
-        // sc.close();
+        String word = scanner.next();
 
-        return selection;
+        return Integer.parseInt(word);
     }
 }

--- a/common/core/src/main/java/zingg/common/core/util/CLIReader.java
+++ b/common/core/src/main/java/zingg/common/core/util/CLIReader.java
@@ -1,0 +1,21 @@
+package zingg.common.core.util;
+
+import java.util.Scanner;
+
+public class CLIReader {
+    private static final String userInputRegex = "[0129]";
+
+    public static int readCliInput() {
+        Scanner sc = new Scanner(System.in);
+
+        while (!sc.hasNext(userInputRegex)) {
+            sc.next();
+            System.out.println("Nope, please enter one of the allowed options!");
+        }
+        String word = sc.next();
+        int selection = Integer.parseInt(word);
+        // sc.close();
+
+        return selection;
+    }
+}


### PR DESCRIPTION
Summary of Changes:
- Improvised Labeller.java to follow the Single Responsibility Principle
- Created a new generic class CLIReader, independent of Labeller.java, which can be used by other classes as well.
- Segregated the content for processRecordsCli into two methods for better understanding of code
- Initialised Class variable in the constructor to avoid NullPointerException and keep getter methods simple
- Improvised Exception Handling to avoid NullPointerExceptions and log/throw meaningful messages.

OBSERVATION 1
- Labeller.java is being used for the labelling of data to be processed. But along with labelling we are also reading from CLI to get user input for digits 0,1,2,9
- The CLI operations should be a part of another class such as CLIReader or part of LabellerUtils but not Labeller.java (According to Single responsibility principle from SOLID Principles)
- Example - Method displayRecordsAndGetUserInput is unrelated to the core purpose of Labeller and its logic to get the user input should be separated. In this case i have made CLIReader to be generic and the regex to be passed into the method so if need be we can use CLIReader in other classes as well. 

OBSERVATION 2
- processRecordsCli is a large method containing multiple smaller logics. Broken it down into two methods to better understanding of logic being implemented.

OBSERVATION 3
- We are using getTrainingDataModel method to initialise ITrainingDataModel instance variable. Initialising that variables should be done in the constructor as in case someone in the class or child class accessed the variable directly it can be null. 
Better than to lazy initialise it in its getter is to initialise in the constructor to about NullPointerExceptions.
- Same for ILabelDataViewHelper variable being initialised inside getlabelDataViewHelper
- This will help keep both getters and setters for both these class variables clean
- Once we move its initialisation to constructor we can directly access these variables without relying on getters to access these two variables - trainingDataModel and labelDataViewHelper, 

OBSERVATION 4: EXCEPTION HANDLING
- Exception handling can be improved for getUnmarkedRecords
getUnmarkedRecords unnececcarily have multiple catch blocks which can be flattened into one. Also it doesnt have proper logging for ZinggClientException
- Also we are catching Exception first which will catch all the exceptions. So we should be catching ZinggClientException first or include it along with Exception in a single catch block.
- In case this method(getUnmarkedRecords) falls into a catch block we are returning unmarkedRecords = null, which can end up affecting the downstream services if it is not handled well in other services. 
- If it is expected for getUnmarkedRecords to return null in failure cases it is better to throw a ZinggClientException to the downstream services as well.
