### PR TITLE
dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "*" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "io.netty:*"
+      - dependency-name: "com.fasterxml.jackson.*:*"
+      - dependency-name: "org.lz4:lz4-java"
+      - dependency-name: "org.apache.spark:*"
+      - dependency-name: "org.eclipse.jetty:*"
+      - dependency-name: "org.apache.logging.log4j:*"


### PR DESCRIPTION
Limits Dependabot to direct dependencies and ignores common "provided" Spark transitives (Jackson, Netty, LZ4) that are not bundled in the final JAR.

before
<img width="950" height="728" alt="Screenshot 2026-05-08 at 1 52 12 PM" src="https://github.com/user-attachments/assets/210a5ebf-abd5-49c0-8bfa-778558104e9e" />

after
<img width="711" height="423" alt="Screenshot 2026-05-08 at 2 23 09 PM" src="https://github.com/user-attachments/assets/9dc0f0f7-736d-45fa-be1f-163e812b7b83" />
