### PR TITLE
added benchmarks for blocking tree optimization

### DIFF
--- a/common/core/src/main/java/zingg/common/core/block/Block.java
+++ b/common/core/src/main/java/zingg/common/core/block/Block.java
@@ -12,11 +12,12 @@ import org.apache.commons.logging.LogFactory;
 import zingg.common.client.FieldDefinition;
 import zingg.common.client.ZFrame;
 import zingg.common.client.ZinggClientException;
+import zingg.common.client.util.ColName;
 import zingg.common.client.util.ListMap;
 import zingg.common.core.feature.FeatureFactory;
 import zingg.common.core.hash.HashFunction;
 
-public abstract class Block<D,R,C,T> implements Serializable {
+public abstract class Block<D, R, C, T> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -24,97 +25,75 @@ public abstract class Block<D,R,C,T> implements Serializable {
 	private final IHashFunctionUtility<D, R, C, T> hashFunctionUtility;
 	private FieldDefinitionStrategy<R> fieldDefinitionStrategy;
 
-	protected ZFrame<D,R,C> dupes;
-	// Class[] types;
-	ListMap<T, HashFunction<D,R,C,T>> functionsMap;
+	protected ZFrame<D, R, C> dupes;
+	ListMap<T, HashFunction<D, R, C, T>> functionsMap;
 	long maxSize;
-	ZFrame<D,R,C> training;
-	protected ListMap<HashFunction<D,R,C,T>, String> childless;
+	ZFrame<D, R, C> training;
+	protected ListMap<HashFunction<D, R, C, T>, String> childless;
 
 	public Block() {
 		this.hashFunctionUtility = HashFunctionUtilityFactory.getHashFunctionUtility(HashUtility.CACHED);
 	}
 
-	public Block(ZFrame<D,R,C> training, ZFrame<D,R,C> dupes) {
+	public Block(ZFrame<D, R, C> training, ZFrame<D, R, C> dupes) {
 		this();
 		this.training = training;
 		this.dupes = dupes;
-		childless =  new ListMap<HashFunction<D,R,C,T>, String>();
-		// types = getSampleTypes();
-		/*
-		 * for (Class type : types) { LOG.info("Type is " + type); }
-		 */
+		childless = new ListMap<HashFunction<D, R, C, T>, String>();
 	}
 
-	public Block(ZFrame<D,R,C> training, ZFrame<D,R,C> dupes,
-		ListMap<T, HashFunction<D, R, C, T>> functionsMap, long maxSize, FieldDefinitionStrategy<R> fieldDefinitionStrategy) {
+	public Block(ZFrame<D, R, C> training, ZFrame<D, R, C> dupes,
+				 ListMap<T, HashFunction<D, R, C, T>> functionsMap, long maxSize, FieldDefinitionStrategy<R> fieldDefinitionStrategy) {
 		this(training, dupes);
 		this.functionsMap = functionsMap;
-		// functionsMap.prettyPrint();
 		this.maxSize = maxSize;
 		this.fieldDefinitionStrategy = fieldDefinitionStrategy;
 	}
 
-	/**
-	 * @return the dupes
-	 */
-	public ZFrame<D,R,C> getDupes() {
+	@SuppressWarnings("unchecked")
+	public Block(ZFrame<D, R, C> training, ZFrame<D, R, C> dupes,
+				 ListMap<T, HashFunction<D, R, C, T>> functionsMap, long maxSize,
+				 FieldDefinitionStrategy<R> fieldDefinitionStrategy, HashUtility hashUtility) {
+		this.hashFunctionUtility = HashFunctionUtilityFactory.getHashFunctionUtility(hashUtility);
+		this.training = training;
+		this.dupes = dupes;
+		this.childless = new ListMap<HashFunction<D, R, C, T>, String>();
+		this.functionsMap = functionsMap;
+		this.maxSize = maxSize;
+		this.fieldDefinitionStrategy = fieldDefinitionStrategy;
+	}
+
+	public ZFrame<D, R, C> getDupes() {
 		return dupes;
 	}
 
-	/**
-	 * @param dupes
-	 *            the dupes to set
-	 */
-	public void setDupes(ZFrame<D,R,C> dupes) {
+	public void setDupes(ZFrame<D, R, C> dupes) {
 		this.dupes = dupes;
 	}
 
-	/**
-	 * @return the types
-	 * 
-	 */
-
-	/**
-	 * @param types
-	 * the types to set
-	 * 
-	 *           
-	 * @return the maxSize
-	 */
 	public long getMaxSize() {
 		return maxSize;
 	}
 
-	/**
-	 * @param maxSize
-	 *  the maxSize to set
-	 */
 	public void setMaxSize(long maxSize) {
 		this.maxSize = maxSize;
 	}
 
-	/**
-	 * @return the functionsMap
-	 */
-	public Map<T, List<HashFunction<D,R,C,T>>> getFunctionsMap() {
+	public Map<T, List<HashFunction<D, R, C, T>>> getFunctionsMap() {
 		return functionsMap;
 	}
 
-	
-	protected void setFunctionsMap(ListMap<T, HashFunction<D,R,C,T>> m) {
+	protected void setFunctionsMap(ListMap<T, HashFunction<D, R, C, T>> m) {
 		this.functionsMap = m;
 	}
 
-	protected Canopy<R> getCanopy(){
+	protected Canopy<R> getCanopy() {
 		return new Canopy<R>();
 	}
-	
-	public Canopy<R>getNodeFromCurrent(Canopy<R>node, HashFunction<D,R,C,T> function,
-			FieldDefinition context) {
-		Canopy<R>trial = getCanopy();
+
+	public Canopy<R> getNodeFromCurrent(Canopy<R> node, HashFunction<D, R, C, T> function, FieldDefinition context) {
+		Canopy<R> trial = getCanopy();
 		trial = node.copyTo(trial);
-		// node.training, node.dupeN, function, context);
 		trial.function = function;
 		trial.context = context;
 		return trial;
@@ -124,105 +103,202 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		c.estimateElimCount();
 	}
 
-	public Canopy<R>getBestNode(Tree<Canopy<R>> tree, Canopy<R>parent, Canopy<R>node,
-			List<FieldDefinition> fieldsOfInterest) throws Exception {
+	public Canopy<R> getBestNodeOriginal(Tree<Canopy<R>> tree, Canopy<R> parent, Canopy<R> node,
+										 List<FieldDefinition> fieldsOfInterest) throws Exception {
 		long least = Long.MAX_VALUE;
-		int maxElimination = 0;
-		Canopy<R>best = null;
+		Canopy<R> best = null;
 		List<FieldDefinition> adjustedFieldOfInterestList = getFieldOfInterestList(fieldsOfInterest, node);
 		for (FieldDefinition field : adjustedFieldOfInterestList) {
-			if (LOG.isDebugEnabled()){
-				LOG.debug("Trying for " + field + " with data type " + field.getDataType() + " and real dt " 
-					+ getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Trying for " + field + " with data type " + field.getDataType() + " and real dt "
+						+ getFeatureFactory().getDataTypeFromString(field.getDataType()));
 			}
-			//Class type = FieldClass.getFieldClassClass(field.getFieldClass());
 			FieldDefinition context = field;
-			if (least ==0) break;//how much better can it get?
-			// applicable functions
-			List<HashFunction<D,R,C,T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
-			if (LOG.isDebugEnabled()){
+			if (least == 0) break;
+			List<HashFunction<D, R, C, T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			if (LOG.isDebugEnabled()) {
 				LOG.debug("functions are " + functions);
 			}
-			
 			if (functions != null) {
-				
-				for (HashFunction function : functions) {
-					// /if (!used.contains(field.getIndex(), function) &&
-					if (least ==0) break;//how much better can it get?
-					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node) //&&
-							//!childless.contains(function, field.fieldName)
-							) 
-							{
-						if (LOG.isDebugEnabled()){
-							LOG.debug("Evaluating field " + field.fieldName
-								+ " and function " + function + " for " + field.dataType);
+				for (HashFunction<D, R, C, T> function : functions) {
+					if (least == 0) break;
+					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node)) {
+						if (LOG.isDebugEnabled()) {
+							LOG.debug("Evaluating field " + field.fieldName + " and function " + function + " for " + field.dataType);
 						}
-						Canopy<R>trial = getNodeFromCurrent(node, function,
-								context);
+						Canopy<R> trial = getNodeFromCurrent(node, function, context);
 						estimateElimCount(trial, least);
 						long elimCount = trial.getElimCount();
-
-						
-						//int trSize = (int) Math.ceil(0.02d * node.dupeN.count());
-						//boolean isNotEliminatingMoreThan1Percent = elimCount <= trSize ? true
-						//		: false;
-
 						if (LOG.isDebugEnabled()) {
-							LOG.debug("Elim Count is " + elimCount
-						
-								+ " ,least is "
-								+ least
-								//+ " , training is "
-								//+ node.training
-								+ ", dupe count " + node.dupeN.size());
+							LOG.debug("Elim Count is " + elimCount + " ,least is " + least + ", dupe count " + node.dupeN.size());
 						}
 						if (least > elimCount) {
 							long childrenSize = trial.estimateCanopies();
 							if (childrenSize > 1) {
-						
-								// && isNotEliminatingMoreThan1Percent) {
 								if (LOG.isDebugEnabled()) {
 									LOG.debug("Yes, this fn has potential " + function);
 								}
 								least = elimCount;
 								best = trial;
 								best.elimCount = least;
-								/*if (elimCount == 0) {
-									LOG.debug("Out of this tyranny " + function);
-									break;
-								}*/
-							}
-							else {
-								if (LOG.isDebugEnabled()){
+							} else {
+								if (LOG.isDebugEnabled()) {
 									LOG.debug("No child " + function);
 								}
-								//childless.add(function, field.fieldName);
 							}
-							
 						}
 					}
 				}
-			}
-			else {
+			} else {
 				LOG.debug("functions are null??????");
 			}
 		}
 		return best;
-
 	}
 
-	/**
-	 * Holy Grail of Standalone
-	 * 
-	 * @param tree
-	 * @param parent
-	 * @param node
-	 * @param used
-	 * @return
-	 * @throws ZinggClientException 
-	 */
-	public Tree<Canopy<R>> getBlockingTree(Tree<Canopy<R>> tree, Canopy<R>parent,
-			Canopy<R>node, List<FieldDefinition> fieldsOfInterest) throws Exception, ZinggClientException {
+	// Original row extraction (function.apply per row, no precomputed values) + early exit.
+	// Everything else same as original: estimateCanopies check, buildDupeRemaining for winner only.
+	public Canopy<R> getBestNodeOriginalEarlyExit(Tree<Canopy<R>> tree, Canopy<R> parent, Canopy<R> node,
+												  List<FieldDefinition> fieldsOfInterest) throws Exception {
+		long least = Long.MAX_VALUE;
+		Canopy<R> best = null;
+		List<FieldDefinition> adjustedFieldOfInterestList = getFieldOfInterestList(fieldsOfInterest, node);
+		for (FieldDefinition field : adjustedFieldOfInterestList) {
+			if (least == 0) break;
+			List<HashFunction<D, R, C, T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			if (functions != null) {
+				for (HashFunction<D, R, C, T> function : functions) {
+					if (least == 0) break;
+					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node)) {
+						Canopy<R> trial = getNodeFromCurrent(node, function, field);
+						long elimCount = trial.countEliminationsWithRowExtraction(least);
+						trial.elimCount = elimCount;
+						if (least > elimCount) {
+							long childrenSize = trial.estimateCanopies();
+							if (childrenSize > 1) {
+								least = elimCount;
+								best = trial;
+								best.elimCount = least;
+							}
+						}
+					}
+				}
+			}
+		}
+		if (best != null) {
+			best.buildDupeRemaining();
+		}
+		return best;
+	}
+
+	// Precomputed values + no estimateCanopies, but NO early exit on the counting loop.
+	// Isolates the contribution of early exit vs. precomputed values.
+	public Canopy<R> getBestNodeNoEarlyExit(Tree<Canopy<R>> tree, Canopy<R> parent, Canopy<R> node,
+											List<FieldDefinition> fieldsOfInterest) throws Exception {
+		long least = Long.MAX_VALUE;
+		Canopy<R> best = null;
+		List<FieldDefinition> adjustedFieldOfInterestList = getFieldOfInterestList(fieldsOfInterest, node);
+		for (FieldDefinition field : adjustedFieldOfInterestList) {
+			if (least == 0) break;
+			List<HashFunction<D, R, C, T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			if (functions != null && !functions.isEmpty()) {
+				List<R> dupeN = node.getDupeN();
+				Object[] preVals1 = new Object[dupeN.size()];
+				Object[] preVals2 = new Object[dupeN.size()];
+				HashFunction<D, R, C, T> refFn = functions.get(0);
+				for (int i = 0; i < dupeN.size(); i++) {
+					preVals1[i] = refFn.getAs(dupeN.get(i), field.fieldName);
+					preVals2[i] = refFn.getAs(dupeN.get(i), ColName.COL_PREFIX + field.fieldName);
+				}
+				for (HashFunction<D, R, C, T> function : functions) {
+					if (least == 0) break;
+					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node)) {
+						Canopy<R> trial = getNodeFromCurrent(node, function, field);
+						long elimCount = trial.countEliminationsWithValues(preVals1, preVals2, Long.MAX_VALUE);
+						trial.elimCount = elimCount;
+						if (least > elimCount && (elimCount > 0 || trial.estimateCanopies() > 1)) {
+							least = elimCount;
+							best = trial;
+							best.elimCount = least;
+						}
+					}
+				}
+			} else {
+				LOG.debug("functions are null??????");
+			}
+		}
+		if (best != null) {
+			best.buildDupeRemaining();
+		}
+		return best;
+	}
+
+	public Canopy<R> getBestNode(Tree<Canopy<R>> tree, Canopy<R> parent, Canopy<R> node,
+								 List<FieldDefinition> fieldsOfInterest) throws Exception {
+		long least = Long.MAX_VALUE;
+		Canopy<R> best = null;
+		List<FieldDefinition> adjustedFieldOfInterestList = getFieldOfInterestList(fieldsOfInterest, node);
+		for (FieldDefinition field : adjustedFieldOfInterestList) {
+			if (least == 0) break;
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Trying for " + field + " with data type " + field.getDataType() + " and real dt "
+						+ getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			}
+			List<HashFunction<D, R, C, T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("functions are " + functions);
+			}
+			if (functions != null && !functions.isEmpty()) {
+				// Precompute raw field values once per row for this field.
+				// All functions share the same getAs for a given data type, so
+				// we use the first function as a representative extractor.
+				List<R> dupeN = node.getDupeN();
+				Object[] preVals1 = new Object[dupeN.size()];
+				Object[] preVals2 = new Object[dupeN.size()];
+				HashFunction<D, R, C, T> refFn = functions.get(0);
+				for (int i = 0; i < dupeN.size(); i++) {
+					preVals1[i] = refFn.getAs(dupeN.get(i), field.fieldName);
+					preVals2[i] = refFn.getAs(dupeN.get(i), ColName.COL_PREFIX + field.fieldName);
+				}
+
+				for (HashFunction<D, R, C, T> function : functions) {
+					if (least == 0) break;
+					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node)) {
+						if (LOG.isDebugEnabled()) {
+							LOG.debug("Evaluating field " + field.fieldName + " and function " + function + " for " + field.dataType);
+						}
+						Canopy<R> trial = getNodeFromCurrent(node, function, field);
+						long elimCount = trial.countEliminationsWithValues(preVals1, preVals2, least);
+						trial.elimCount = elimCount;
+						if (LOG.isDebugEnabled()) {
+							LOG.debug("Elim Count is " + elimCount + " ,least is " + least + ", dupe count " + node.dupeN.size());
+						}
+						// Skip estimateCanopies() when elimCount > 0: an eliminated pair
+						// means ≥2 distinct hash values in training, so childrenSize > 1
+						// is guaranteed. When elimCount == 0 we must still check.
+						if (least > elimCount && (elimCount > 0 || trial.estimateCanopies() > 1)) {
+							if (LOG.isDebugEnabled()) {
+								LOG.debug("Yes, this fn has potential " + function);
+							}
+							least = elimCount;
+							best = trial;
+							best.elimCount = least;
+						}
+					}
+				}
+			} else {
+				LOG.debug("functions are null??????");
+			}
+		}
+		// Build dupeRemaining only for the winner — all other candidates discarded.
+		if (best != null) {
+			best.buildDupeRemaining();
+		}
+		return best;
+	}
+
+	public Tree<Canopy<R>> getBlockingTree(Tree<Canopy<R>> tree, Canopy<R> parent,
+										   Canopy<R> node, List<FieldDefinition> fieldsOfInterest) throws Exception, ZinggClientException {
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("Tree so far ");
 			LOG.debug(tree);
@@ -233,146 +309,98 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		}
 		if (size > maxSize && node.getDupeN() != null && node.getDupeN().size() > 0) {
 			LOG.debug("Size is bigger ");
-			Canopy<R>best = getBestNode(tree, parent, node, fieldsOfInterest);
+			Canopy<R> best = getBestNode(tree, parent, node, fieldsOfInterest);
 			if (best != null) {
-				//add function, context info for this best node in set
 				hashFunctionUtility.addHashFunctionIfRequired(best);
 				if (LOG.isDebugEnabled()) {
 					LOG.debug(" HashFunction is " + best + " and node is " + node);
 				}
 				best.copyTo(node);
-				// used.add(node.context.getOperandFields()[0],
-				// best.getFunction());
-				// used.add(1, best.getFunction());
 				if (tree == null && parent == null) {
 					tree = new Tree<Canopy<R>>(node);
-				} 
-				/*else {
-					// /tree.addLeaf(parent, node);
-					used = new ListMap<Integer, HashFunction>();
-				}*/
+				}
 				List<Canopy<R>> canopies = node.getCanopies();
 				if (LOG.isDebugEnabled()) {
 					LOG.debug(" Children size is " + canopies.size());
 				}
-				for (Canopy<R>n : canopies) {
+				for (Canopy<R> n : canopies) {
 					node.clearBeforeSaving();
 					tree.addLeaf(node, n);
 					if (LOG.isDebugEnabled()) {
 						LOG.debug(" Finding for " + n);
 					}
-				
 					getBlockingTree(tree, node, n, fieldsOfInterest);
 				}
-				//remove function, context info for this best node as we are returning from best node
 				hashFunctionUtility.removeHashFunctionIfRequired(best);
-			}
-			else {
+			} else {
 				node.clearBeforeSaving();
 			}
 		} else {
 			if ((node.getDupeN() == null) || (node.getDupeN().size() == 0)) {
 				LOG.warn("Ran out of training at size " + size + " for node " + node);
-			}
-			else {
+			} else {
 				LOG.debug("Min size reached " + size + " for node " + node);
-				if (tree==null) {
+				if (tree == null) {
 					throw new ZinggClientException("Unable to create Zingg models due to insufficient data. Please run Zingg after adding more data");
 				}
 			}
-			// tree.addLeaf(parent, node);
 			node.clearBeforeSaving();
 		}
-
 		return tree;
 	}
 
-//	public boolean isFunctionUsed(FieldDefinition fieldDefinition, HashFunction<D, R, C, T> function) {
-//		return hashFunctionsInCurrentNodePath.contains(getKey(fieldDefinition, function));
-//	}
+	protected boolean isHashFunctionUsed(FieldDefinition field, HashFunction<D, R, C, T> function,
+										 Tree<Canopy<R>> tree, Canopy<R> node) {
+		return hashFunctionUtility.isHashFunctionUsed(field, function, tree, node);
+	}
 
 	public List<Canopy<R>> getHashSuccessors(Collection<Canopy<R>> successors, Object hash) {
 		List<Canopy<R>> retCanopy = new ArrayList<Canopy<R>>();
-		for (Canopy<R>c: successors) {
-			if (hash == null && c!= null && c.getHash() == null) retCanopy.add(c);
-			if (c!= null && c.getHash() != null && c.getHash().equals(hash)) {
+		for (Canopy<R> c : successors) {
+			if (hash == null && c != null && c.getHash() == null) {
+				retCanopy.add(c);
+			}
+			if (c != null && c.getHash() != null && c.getHash().equals(hash)) {
 				retCanopy.add(c);
 			}
 		}
 		return retCanopy;
 	}
 
-	/*public static StringBuilder applyTree(Row tuple, Tree<Canopy<R>> tree,
-			Canopy<R>root, StringBuilder result) {
-		LOG.debug("Applying root " + root + " on " + tuple);
-		if (root.function != null) {
-			Object hash = root.function.apply(tuple, root.context.fieldName);
-			LOG.debug("Applied root " + root + " and got " + hash);
-			result = result.append("|").append(hash);
-			for (Canopy<R>c : getHashSuccessors(tree.getSuccessors(root), hash)) {
-				// LOG.info("Successr hash " + c.getHash() + " and our hash "+
-				// hash);
-				if (c != null) {
-					// //LOG.debug("c.hash " + c.getHash() + " and our hash " + hash);
-					if ((c.getHash() != null)) {
-						//LOG.debug("Hurdle one over ");
-						//if ((c.getHash().equals(hash))) {
-							// //LOG.debug("Hurdle 2 start " + c);
-							applyTree(tuple, tree, c, result);
-							// //LOG.debug("Hurdle 2 over ");
-						//}
-					}
-				}
-			}
-		}
-		return result;
-	}*/
-	
 	public static <R> StringBuilder applyTree(R tuple, Tree<Canopy<R>> tree,
-			Canopy<R>root, StringBuilder result) {
+											  Canopy<R> root, StringBuilder result) {
 		if (root.function != null) {
 			Object hash = root.function.apply(tuple, root.context.fieldName);
-			
 			result = result.append("|").append(hash);
-			for (Canopy<R>c : tree.getSuccessors(root)) {
-				// LOG.info("Successr hash " + c.getHash() + " and our hash "+
-				// hash);
+			for (Canopy<R> c : tree.getSuccessors(root)) {
 				if (c != null) {
-					// //LOG.debug("c.hash " + c.getHash() + " and our hash " + hash);
 					if ((c.getHash() != null)) {
-						//LOG.debug("Hurdle one over ");
 						if ((c.getHash().equals(hash))) {
-							// //LOG.debug("Hurdle 2 start " + c);
 							applyTree(tuple, tree, c, result);
-							// //LOG.debug("Hurdle 2 over ");
 						}
 					}
 				}
 			}
 		}
-		//LOG.debug("apply first step clustering result " + result);
 		return result;
 	}
 
-	public void printTree(Tree<Canopy<R>> tree,
-			Canopy<R>root) {
+	public void printTree(Tree<Canopy<R>> tree, Canopy<R> root) {
 		if (root.dupeN != null) {
 			LOG.info(" dupeN not null " + root);
 			LOG.info(root.dupeN.size());
 		}
-		
 		if (root.dupeRemaining != null) {
 			LOG.info(" dupeRemaining not null " + root);
 			LOG.info(root.dupeRemaining.size());
 		}
-		
 		if (root.training != null) {
 			LOG.info(" training not null " + root);
 			LOG.info(root.training.size());
 		}
-		for (Canopy<R>c : tree.getSuccessors(root)) {
+		for (Canopy<R> c : tree.getSuccessors(root)) {
 			printTree(tree, c);
-		}			
+		}
 	}
 
 	public List<FieldDefinition> getFieldOfInterestList(List<FieldDefinition> fieldDefinitions, Canopy<R> node) {
@@ -385,4 +413,3 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		this.fieldDefinitionStrategy = fieldDefinitionStrategy;
 	}
 }
-

--- a/common/core/src/main/java/zingg/common/core/block/Canopy.java
+++ b/common/core/src/main/java/zingg/common/core/block/Canopy.java
@@ -14,8 +14,8 @@ import zingg.common.client.util.ColName;
 import zingg.common.client.util.ListMap;
 import zingg.common.core.hash.HashFunction;
 
-
 public class Canopy<R> implements Serializable {
+
 	private static final long serialVersionUID = -229533781044789499L;
 
 	public static final Log LOG = LogFactory.getLog(Canopy.class);
@@ -39,191 +39,103 @@ public class Canopy<R> implements Serializable {
 	}
 
 	public Canopy(List<R> training, List<R> dupeN) {
-		this.training = training; //.cache();
+		this.training = training;
 		this.dupeN = dupeN;
 	}
 
 	public Canopy(List<R> training, List<R> dupeN, HashFunction function,
-			FieldDefinition context) {
+				  FieldDefinition context) {
 		this(training, dupeN);
 		this.function = function;
 		this.context = context;
-		// prepare();
 	}
 
-	/**
-	 * @return the function
-	 */
 	public HashFunction getFunction() {
 		return function;
 	}
 
-	/**
-	 * @param function
-	 *            the function to set
-	 */
 	public void setFunction(HashFunction function) {
 		this.function = function;
 	}
 
-	/**
-	 * @return the context
-	 */
 	public FieldDefinition getContext() {
 		return context;
 	}
 
-	/**
-	 * @param context
-	 *            the context to set
-	 */
 	public void setContext(FieldDefinition context) {
 		this.context = context;
 	}
 
-	
-
-	/**
-	 * @return the dupeN
-	 */
 	public List<R> getDupeN() {
 		return dupeN;
 	}
 
-	/**
-	 * @param dupeN
-	 *            the dupeN to set
-	 */
 	public void setDupeN(List<R> dupeN) {
 		this.dupeN = dupeN;
 	}
 
-	/**
-	 * @return the elimCount
-	 */
 	public long getElimCount() {
 		return elimCount;
 	}
 
-	/**
-	 * @param elimCount
-	 *            the elimCount to set
-	 */
 	public void setElimCount(long elimCount) {
 		this.elimCount = elimCount;
 	}
 
-	/**
-	 * @return the hash
-	 */
 	public Object getHash() {
 		return hash;
 	}
 
-	/**
-	 * @param hash
-	 *            the hash to set
-	 */
 	public void setHash(Object hash) {
 		this.hash = hash;
 	}
 
-	/**
-	 * @return the training
-	 */
 	public List<R> getTraining() {
 		return training;
 	}
 
-	/**
-	 * @param training
-	 *            the training to set
-	 */
 	public void setTraining(List<R> training) {
 		this.training = training;
 	}
 
 	public List<Canopy<R>> getCanopies() {
-		//long ts = System.currentTimeMillis();
-		/*
-		List<R> newTraining = function.apply(training, context.fieldName, ColName.HASH_COL).cache();
-		LOG.debug("getCanopies0" + (System.currentTimeMillis() - ts));
-		List<Canopy> returnCanopies = new ArrayList<Canopy>();
-		//first find unique hashes
-		//then split the training into per hash
-		List<R> uniqueHashes = newTraining.select(ColName.HASH_COL).distinct().collectAsList();
-		LOG.debug("getCanopies1" + (System.currentTimeMillis() - ts));
-		for (Row row : uniqueHashes) {
-			Object key = row.get(0);
-			List<R> tupleList = newTraining.filter(newTraining.col(ColName.HASH_COL).equalTo(key))
-					.cache();
-			tupleList = tupleList.drop(ColName.HASH_COL);
-			Canopy can = new Canopy(tupleList, dupeRemaining);
-			//LOG.debug(" canopy size is " + tupleList.count() + " for  hash "
-			//		+ key);
-			can.hash = key;
-			returnCanopies.add(can);
-		}
-		LOG.debug("getCanopies2" + (System.currentTimeMillis() - ts));
-		return returnCanopies;*/
 		ListMap<Object, R> hashes = new ListMap<Object, R>();
 		List<Canopy<R>> returnCanopies = new ArrayList<Canopy<R>>();
-		
 		for (R r : training) {
 			hashes.add(function.apply(r, context.fieldName), r);
 		}
-		for (Object o: hashes.keySet()) {
+		for (Object o : hashes.keySet()) {
 			Canopy<R> can = new Canopy<R>(hashes.get(o), dupeRemaining);
 			can.hash = o;
 			returnCanopies.add(can);
 		}
 		hashes = null;
-		//LOG.debug("getCanopies2" + (System.currentTimeMillis() - ts));
 		return returnCanopies;
 	}
-	
+
 	public long estimateCanopies() {
-		//long ts = System.currentTimeMillis();	
 		Set<Object> hashes = new HashSet<Object>();
 		for (R r : training) {
 			hashes.add(function.apply(r, context.fieldName));
 		}
-		/*
-		List<R> newTraining = function.apply(training, context.fieldName, ColName.HASH_COL);
-		long uniqueHashes = (long) newTraining.select(functions.approxCountDistinct(
-				newTraining.col(ColName.HASH_COL))).takeAsList(1).get(0).get(0);
-		LOG.debug("estimateCanopies" + (System.currentTimeMillis() - ts) + " and count is " + uniqueHashes);
-		/*newTraining.agg(
-				functions.approxCountDistinct(newTraining.col(ColName.HASH_COL))).show();
-		long ts1 = System.currentTimeMillis();
-		long uniqueHashes = newTraining.select(newTraining.col(ColName.HASH_COL)).distinct().count(); //.distinct().count();
-		LOG.warn("estimateCanopies" + (System.currentTimeMillis() - ts1) + " and count is " + uniqueHashes);
-*/
 		long uniqueHashes = hashes.size();
 		LOG.debug("estimateCanopies- unique hash count is " + uniqueHashes);
-
 		return uniqueHashes;
 	}
 
 	public long getTrainingSize() {
-		return training.size(); 
+		return training.size();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		String str = "";
 		if (context != null) {
 			str = "Canopy [function=" + function + ", context=" + context.fieldName
-				+ ", elimCount=" + elimCount + ", hash=" + hash;
-		}
-		else {
+					+ ", elimCount=" + elimCount + ", hash=" + hash;
+		} else {
 			str = "Canopy [function=" + function + ", context=" + context
-				+ ", elimCount=" + elimCount + ", hash=" + hash;
+					+ ", elimCount=" + elimCount + ", hash=" + hash;
 		}
 		if (training != null) {
 			str += ", training=" + training.size();
@@ -232,83 +144,82 @@ public class Canopy<R> implements Serializable {
 		return str;
 	}
 
-	
-
-	public void estimateElimCount() {
-		//long ts = System.currentTimeMillis();																																																																				
-		//the function is applied to both columns
-		//if hash is equal, they are not going to be eliminated
-		//filter on hash equal and count 
+	public void estimateElimCount() { // O(pairs)
 		LOG.debug("Applying " + function.getName());
 		dupeRemaining = new ArrayList<R>();
-		for(R r: dupeN) {
+		for (R r : dupeN) {
 			Object hash1 = function.apply(r, context.fieldName);
 			Object hash2 = function.apply(r, ColName.COL_PREFIX + context.fieldName);
-			LOG.debug("hash1 " + hash1);		
+			LOG.debug("hash1 " + hash1);
 			LOG.debug("hash2 " + hash2);
-			if (hash1 == null && hash2 ==null) {
+			if (hash1 == null && hash2 == null) {
 				dupeRemaining.add(r);
-			}
-			else if (hash1 != null && hash2 != null && hash1.equals(hash2)) {
+			} else if (hash1 != null && hash2 != null && hash1.equals(hash2)) {
 				dupeRemaining.add(r);
-				LOG.debug("NOT eliminating " );	
-			}
-			else {
-				LOG.debug("eliminating " + r);		
-			}
-		}			
-		elimCount = dupeN.size() - dupeRemaining.size();
-		//LOG.debug("estimateElimCount" + (System.currentTimeMillis() - ts));
-	}
-	
-	/*public ListMap<Object, Row> getHashForDupes(List<R> d) {
-		//dupeRemaining = new ArrayList<R>();
-		ListMap<Object, Row> returnMap = new ListMap<Object, Row>();
-		for (Row pair : d) {
-			Tuple first = pair.getFirst();
-			Tuple second = pair.getSecond();
-			Object hash1 = apply(first);
-			Object hash2 = apply(second);
-			if (hash1 == null) {
-				if (hash2 != null) {
-					//do nothing
-				}
+				LOG.debug("NOT eliminating ");
 			} else {
-				if (!hash1.equals(hash2)) {
-					// LOG.info("Elimniation of " + pair);
-					//do nothing
-				} else {
-					returnMap.add(hash1, pair);
-				}
+				LOG.debug("eliminating " + r);
 			}
 		}
-		return returnMap;
-	}*/
+		elimCount = dupeN.size() - dupeRemaining.size();
+	}
+
+	// Original row extraction via function.apply, but exits early when count exceeds limit.
+	// No ArrayList allocation — used to isolate early-exit contribution without precomputed values.
+	public long countEliminationsWithRowExtraction(long limit) {
+		long count = 0;
+		for (R r : dupeN) {
+			Object hash1 = function.apply(r, context.fieldName);
+			Object hash2 = function.apply(r, ColName.COL_PREFIX + context.fieldName);
+			boolean same = (hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2));
+			if (!same && ++count > limit) return count;
+		}
+		elimCount = count;
+		return count;
+	}
+
+	// Count eliminations using precomputed raw field values; exits early once count
+	// exceeds limit. No ArrayList allocation — called for every candidate in getBestNode.
+	public long countEliminationsWithValues(Object[] vals1, Object[] vals2, long limit) {
+		long count = 0;
+		for (int i = 0; i < dupeN.size(); i++) {
+			Object hash1 = function.applyToValue(vals1[i]);
+			Object hash2 = function.applyToValue(vals2[i]);
+			boolean same = (hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2));
+			if (!same && ++count > limit) return count;
+		}
+		return count;
+	}
+
+	// Build dupeRemaining for the winning candidate only — called once per getBestNode.
+	public void buildDupeRemaining() {
+		dupeRemaining = new ArrayList<>(dupeN.size());
+		for (R r : dupeN) {
+			Object hash1 = function.apply(r, context.fieldName);
+			Object hash2 = function.apply(r, ColName.COL_PREFIX + context.fieldName);
+			if ((hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2))) {
+				dupeRemaining.add(r);
+			}
+		}
+		elimCount = dupeN.size() - dupeRemaining.size();
+	}
 
 	public Canopy copyTo(Canopy copyTo) {
 		copyTo.function = function;
 		copyTo.context = context;
-		// list of duplicates passed from parent
 		copyTo.dupeN = dupeN;
-		// number of duplicates eliminated after function applied on fn context
 		copyTo.elimCount = elimCount;
-		// hash of canopy
 		copyTo.hash = hash;
-		// training set
 		copyTo.training = training;
-		// duplicates remaining after function is applied
 		copyTo.dupeRemaining = dupeRemaining;
 		return copyTo;
 	}
 
-	/**
-	 * We will call this canopy's clear function to remove dupes, training and
-	 * remaining data before we persist to disk this method is to be called just
-	 * before
-	 */
 	public void clearBeforeSaving() {
 		this.training = null;
-		// this.elimCount = null;
 		this.dupeN = null;
 		this.dupeRemaining = null;
 	}

--- a/common/core/src/main/java/zingg/common/core/hash/HashFunction.java
+++ b/common/core/src/main/java/zingg/common/core/hash/HashFunction.java
@@ -5,79 +5,84 @@ import java.io.Serializable;
 import zingg.common.client.ZFrame;
 
 public abstract class HashFunction<D,R,C,T> implements Serializable{
-		/**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		protected T dataType;
-		protected String name;
-		protected boolean isUdf = true;
-		protected T returnType;
-		
-        public HashFunction() {           
-        }
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+	protected T dataType;
+	protected String name;
+	protected boolean isUdf = true;
+	protected T returnType;
 
-		public HashFunction(String name) {
-			this.name = name;
-		}
-		
-		public HashFunction(String name, T cl, T returnType) {
-			this.name = name;
-			this.dataType = cl;
-			this.returnType = returnType;
-		}
-	
-		public HashFunction(String name, T cl, T returnType, boolean isUdf) {
-			this(name, cl, returnType);
-			this.isUdf = isUdf;
-		}
-		
-		public T getDataType() {
-			return dataType;
-		}
-		
-		
-	
-		public String getName() {
-			return name;
-		}
+	public HashFunction() {
+	}
 
-		public void setName(String name) {
-			this.name = name;
-		}
+	public HashFunction(String name) {
+		this.name = name;
+	}
 
-		public boolean isUdf() {
-			return isUdf;
-		}
+	public HashFunction(String name, T cl, T returnType) {
+		this.name = name;
+		this.dataType = cl;
+		this.returnType = returnType;
+	}
 
-		public void setUdf(boolean isUdf) {
-			this.isUdf = isUdf;
-		}
+	public HashFunction(String name, T cl, T returnType, boolean isUdf) {
+		this(name, cl, returnType);
+		this.isUdf = isUdf;
+	}
 
-		public T getReturnType() {
-			return returnType;
-		}
+	public T getDataType() {
+		return dataType;
+	}
 
-		public void setReturnType(T returnType) {
-			this.returnType = returnType;
-		}
 
-		public void setDataType(T dataType) {
-			this.dataType = dataType;
-		}
 
-		
-		public abstract ZFrame<D,R,C> apply(ZFrame<D,R,C> ds, String column, String newColumn) ;
+	public String getName() {
+		return name;
+	}
 
-		public abstract Object getAs(R r, String column);
+	public void setName(String name) {
+		this.name = name;
+	}
 
-		public abstract Object getAs(D df, R r, String column); // added for SnowFrame getAsString method 
-		
-		public abstract Object apply(R r, String column);
+	public boolean isUdf() {
+		return isUdf;
+	}
 
-		public abstract Object apply(D df, R r, String column); // added for SnowFrame getAsString method
+	public void setUdf(boolean isUdf) {
+		this.isUdf = isUdf;
+	}
 
-		/* 
+	public T getReturnType() {
+		return returnType;
+	}
+
+	public void setReturnType(T returnType) {
+		this.returnType = returnType;
+	}
+
+	public void setDataType(T dataType) {
+		this.dataType = dataType;
+	}
+
+
+	public abstract ZFrame<D,R,C> apply(ZFrame<D,R,C> ds, String column, String newColumn) ;
+
+	public abstract Object getAs(R r, String column);
+
+	public abstract Object getAs(D df, R r, String column); // added for SnowFrame getAsString method
+
+	public abstract Object apply(R r, String column);
+
+	public abstract Object apply(D df, R r, String column); // added for SnowFrame getAsString method
+
+	// Apply the hash transformation to an already-extracted field value.
+	// Separates extraction (getAs) from hashing so callers can precompute
+	// field values once per row and reuse them across multiple functions.
+	public abstract Object applyToValue(Object value);
+
+		/*
 		public abstract void writeCustomObject(ObjectOutputStream out) throws IOException;
 		public abstract void readCustomObject(ObjectInputStream ois) throws ClassNotFoundException, IOException;
 		
@@ -97,6 +102,6 @@ public abstract class HashFunction<D,R,C,T> implements Serializable{
 				readCustomObject(ois);
 			}
 			*/
-	
+
 }
 

--- a/common/core/src/test/java/zingg/common/core/block/TestBlockingTreeUtil.java
+++ b/common/core/src/test/java/zingg/common/core/block/TestBlockingTreeUtil.java
@@ -2,8 +2,6 @@ package zingg.common.core.block;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import zingg.common.client.arguments.ArgumentServiceImpl;
 import zingg.common.client.arguments.model.Arguments;
 import zingg.common.client.FieldDefinition;
@@ -22,13 +20,11 @@ import zingg.common.core.util.CsvReader;
 import zingg.common.core.util.HashUtil;
 import zingg.common.core.util.Heuristics;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
-import static java.lang.Math.max;
-
 
 public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
 
@@ -36,7 +32,9 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     private int maxDepth = 1;
     private int totalNodes = 0;
     private static String TEST_FILE = "test.csv";
+    private static String LARGE_TEST_FILE = "test_large.csv";
     private static String CONFIG_FILE = "config.json";
+    private static String LARGE_CONFIG_FILE = "config_large.json";
     private final DataUtility dataUtility;
 
     public TestBlockingTreeUtil() {
@@ -71,10 +69,57 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     }
 
 
+    @Test
+    public void testOriginalAndOptimizedProduceSameTree() throws Exception, ZinggClientException {
+        setTestDataBaseLocation();
+        List<Customer> testCustomers = dataUtility.getCustomers(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE);
+        List<CustomerDupe> testCustomerDupes = dataUtility.getCustomerDupes(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE, false);
+        DFObjectUtil<S, D, R, C> dfObjectUtil = getDFObjectUtil();
+
+        ZFrame<D, R, C> zFrameTest = dfObjectUtil.getDFFromObjectList(testCustomers, Customer.class);
+        ZFrame<D, R, C> zFramePositives = dfObjectUtil.getDFFromObjectList(testCustomerDupes, CustomerDupe.class);
+
+        HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + LARGE_CONFIG_FILE)).toURI()).toString();
+        IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(configFile);
+
+        Tree<Canopy<R>> originalTree  = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "original");
+        Tree<Canopy<R>> optimizedTree = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(originalTree, optimizedTree, 1),
+                "Original and optimized getBestNode must produce identical blocking trees");
+    }
+
+    @Test
+    public void testLargeDeepBlockingTree() throws Exception, ZinggClientException {
+        setTestDataBaseLocation();
+        List<Customer> testCustomers = dataUtility.getCustomers(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE);
+        List<CustomerDupe> testCustomerDupes = dataUtility.getCustomerDupes(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE, false);
+        DFObjectUtil<S, D, R, C> dfObjectUtil = getDFObjectUtil();
+
+        ZFrame<D, R, C> zFrameTest = dfObjectUtil.getDFFromObjectList(testCustomers, Customer.class);
+        ZFrame<D, R, C> zFramePositives = dfObjectUtil.getDFFromObjectList(testCustomerDupes, CustomerDupe.class);
+
+        HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + LARGE_CONFIG_FILE)).toURI()).toString();
+        IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(configFile);
+
+        System.out.println("=== STARTING LARGE DEEP BLOCKING TREE TEST ===");
+        Tree<Canopy<R>> blockingTreeDefault = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "default");
+        Tree<Canopy<R>> blockingTreeCached = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(blockingTreeDefault, blockingTreeCached, 1));
+        System.out.println("-------- max depth of trees -------- " + maxDepth);
+        System.out.println("-------- total nodes in a trees ---- " + totalNodes);
+
+        maxDepth = 1; totalNodes = 0;
+        Tree<Canopy<R>> blockingTreeDefault2 = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "default");
+        Tree<Canopy<R>> blockingTreeCached2 = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(blockingTreeDefault2, blockingTreeCached2, 1));
+    }
+
     public void testSameBlockingTree(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives) throws Exception, ZinggClientException {
         setTestDataBaseLocation();
         HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
-        String configFile = Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + CONFIG_FILE)).getFile();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + CONFIG_FILE)).toURI()).toString();
         IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(
                 configFile);
         args.setBlockSize(8);
@@ -92,46 +137,42 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
 
 
     private Tree<Canopy<R>> getBlockingTree(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives, HashUtil<S, D, R, C, T> hashUtil,
-                                         IArguments args, String blockingTreeType) throws Exception, ZinggClientException {
-        long ts = System.currentTimeMillis();
+                                            IArguments args, String blockingTreeType) throws Exception, ZinggClientException {
         Block<D, R, C, T> block;
         if ("cached".equals(blockingTreeType)) {
             block = getCachedBasedBlock(zFrameTest, zFramePositives, hashUtil, args);
+        } else if ("original".equals(blockingTreeType)) {
+            block = getOriginalAlgoBlock(zFrameTest, zFramePositives, hashUtil, args);
         } else {
             block = getDefaultBlock(zFrameTest, zFramePositives, hashUtil, args);
         }
         Canopy<R> root = getCanopy(zFrameTest, zFramePositives, 1);
-        Tree<Canopy<R>> blockingTree = block.getBlockingTree(null, null, root, getFieldDefinitions(args));
-        System.out.println("************ time taken to create " + blockingTreeType + " blocking tree ************, " + (System.currentTimeMillis() - ts));
-        return blockingTree;
+        return block.getBlockingTree(null, null, root, getFieldDefinitions(args));
     }
 
-    //Override with new CacheBasedHashFunctionUtility<D, R, C, T>()
     private Block<D, R, C, T> getCachedBasedBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
                                                   HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
-        try (MockedStatic<HashFunctionUtilityFactory> hashFunctionUtilityFactoryMock = Mockito.mockStatic(HashFunctionUtilityFactory.class)) {
-            hashFunctionUtilityFactoryMock.when(() -> HashFunctionUtilityFactory.getHashFunctionUtility(Mockito.any(HashUtility.class)))
-                    .thenReturn(new CacheBasedHashFunctionUtility<D, R, C, T>());
-            return getBlock(zFrameTest, 1, zFramePositives, -1,
-                    hashUtil.getHashFunctionList(), arguments);
-        }
+        return getBlock(zFrameTest, 1, zFramePositives, -1, hashUtil.getHashFunctionList(), arguments, HashUtility.CACHED);
     }
 
-    //Override with new DefaultHashFunctionUtility<>()
+    private Block<D, R, C, T> getOriginalAlgoBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
+                                                   HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
+        ZFrame<D, R, C> sample = zFrameTest.sample(false, 1);
+        long totalCount = sample.count();
+        long blockSize = Heuristics.getMaxBlockSize(totalCount, arguments.getBlockSize());
+        ZFrame<D, R, C> positives = zFramePositives.coalesce(1);
+        return getOriginalAlgoBlock(sample, positives, hashUtil.getHashFunctionList(), blockSize);
+    }
+
     private Block<D, R, C, T> getDefaultBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
-                                                  HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
-        try (MockedStatic<HashFunctionUtilityFactory> hashFunctionUtilityFactoryMock = Mockito.mockStatic(HashFunctionUtilityFactory.class)) {
-            hashFunctionUtilityFactoryMock.when(() -> HashFunctionUtilityFactory.getHashFunctionUtility(Mockito.any(HashUtility.class)))
-                    .thenReturn(new DefaultHashFunctionUtility<D, R, C, T>());
-            return getBlock(zFrameTest, 1, zFramePositives, -1,
-                    hashUtil.getHashFunctionList(), arguments);
-        }
+                                              HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
+        return getBlock(zFrameTest, 1, zFramePositives, -1, hashUtil.getHashFunctionList(), arguments, HashUtility.DEFAULT);
     }
 
 
     private boolean dfsSameTreeValidation(Tree<Canopy<R>> node1, Tree<Canopy<R>> node2, int depth) {
         totalNodes++;
-        maxDepth = max(maxDepth, depth);
+        maxDepth = Math.max(maxDepth, depth);
 
         //if both the node1 and node2 are null, return true
         if(node1 == null && node2 == null){
@@ -198,13 +239,13 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     }
 
     private Block<D, R, C, T> getBlock(ZFrame<D, R, C> testData, double sampleFraction, ZFrame<D,R,C> positives,
-                                       long blockSize, ListMap<T, HashFunction<D,R,C,T>> hashFunctions, IArguments args) {
+                                       long blockSize, ListMap<T, HashFunction<D,R,C,T>> hashFunctions, IArguments args,
+                                       HashUtility hashUtility) {
         ZFrame<D,R,C> sample = testData.sample(false, sampleFraction);
         long totalCount = sample.count();
         if (blockSize == -1) blockSize = Heuristics.getMaxBlockSize(totalCount, args.getBlockSize());
         positives = positives.coalesce(1);
-        Block<D,R,C,T> cblock = getBlock(sample, positives, hashFunctions, blockSize);
-        return cblock;
+        return getBlock(sample, positives, hashFunctions, blockSize, hashUtility);
     }
 
     private Canopy<R> getCanopy(ZFrame<D,R,C> testData, ZFrame<D,R,C> positives, double sampleFraction) {
@@ -229,4 +270,9 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     protected abstract void setTestDataBaseLocation();
     protected abstract Block<D, R, C, T> getBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
                                                   ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize);
+    protected abstract Block<D, R, C, T> getBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
+                                                  ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize,
+                                                  HashUtility hashUtility);
+    protected abstract Block<D, R, C, T> getOriginalAlgoBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
+                                                              ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize);
 }

--- a/common/core/src/test/java/zingg/common/core/util/CsvReader.java
+++ b/common/core/src/test/java/zingg/common/core/util/CsvReader.java
@@ -6,8 +6,9 @@ import com.opencsv.exceptions.CsvException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,14 @@ public class CsvReader implements ICsvReader {
         return records;
     }
 
-    private CSVReader getCSVReader(String source) throws IOException, URISyntaxException {
-        File file = new File(Objects.requireNonNull(this.getClass().getClassLoader().getResource(source)).toURI());
-        FileReader filereader = new FileReader(file);
-        CSVReader csvReader = new CSVReaderBuilder(filereader)
+    private CSVReader getCSVReader(String source) throws IOException {
+        InputStream is = Objects.requireNonNull(
+            this.getClass().getClassLoader().getResourceAsStream(source),
+            "Resource not found on classpath: " + source
+        );
+        return new CSVReaderBuilder(new InputStreamReader(is))
                 .withSkipLines(1)
                 .build();
-        return csvReader;
     }
 
 }

--- a/common/core/src/test/java/zingg/hash/TestHashFunction.java
+++ b/common/core/src/test/java/zingg/hash/TestHashFunction.java
@@ -36,6 +36,11 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
 
         String expectedName = "hashFunction";
@@ -67,6 +72,11 @@ public class TestHashFunction {
 
             @Override
             public Object apply(String s, Integer integer, String column) {
+                return null;
+            }
+
+            @Override
+            public Object applyToValue(Object value) {
                 return null;
             }
         };
@@ -107,6 +117,11 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
 
         Boolean isUdf = false;
@@ -141,10 +156,15 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
         Integer value = 10;
         String column = "inputColumn";
         assertEquals(null, hashFunction.getAs(value, column));
     }
-    
+
 }

--- a/common/core/src/test/resources/testFebrl/test_large.csv
+++ b/common/core/src/test/resources/testFebrl/test_large.csv
@@ -1,0 +1,520 @@
+rec-0-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-0-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-0-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-0-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-0-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-0-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-0-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-0-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-0-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-0-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-0-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-0-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-0-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-0-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-0-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-0-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-0-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-0-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-0-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-0-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-0-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-0-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-0-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-0-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-0-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-0-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-0-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-0-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-0-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-0-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-0-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-0-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-0-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-0-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-0-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-0-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-0-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-0-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-0-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-0-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-0-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-0-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-0-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-0-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-0-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-0-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-0-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-0-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-0-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-0-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-0-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-0-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-0-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-0-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-0-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-0-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-0-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-0-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-0-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-1-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-1-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-1-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-1-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-1-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-1-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-1-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-1-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-1-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-1-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-1-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-1-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-1-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-1-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-1-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-1-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-1-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-1-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-1-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-1-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-1-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-1-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-1-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-1-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-1-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-1-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-1-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-1-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-1-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-1-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-1-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-1-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-1-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-1-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-1-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-1-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-1-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-1-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-1-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-1-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-1-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-1-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-1-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-1-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-1-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-1-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-1-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-1-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-1-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-1-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-1-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-1-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-1-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-1-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-1-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-1-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-1-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-1-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-2-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-2-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-2-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-2-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-2-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-2-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-2-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-2-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-2-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-2-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-2-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-2-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-2-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-2-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-2-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-2-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-2-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-2-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-2-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-2-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-2-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-2-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-2-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-2-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-2-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-2-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-2-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-2-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-2-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-2-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-2-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-2-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-2-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-2-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-2-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-2-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-2-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-2-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-2-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-2-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-2-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-2-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-2-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-2-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-2-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-2-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-2-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-2-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-2-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-2-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-2-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-2-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-2-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-2-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-2-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-2-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-2-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-2-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-3-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-3-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-3-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-3-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-3-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-3-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-3-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-3-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-3-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-3-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-3-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-3-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-3-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-3-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-3-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-3-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-3-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-3-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-3-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-3-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-3-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-3-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-3-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-3-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-3-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-3-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-3-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-3-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-3-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-3-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-3-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-3-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-3-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-3-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-3-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-3-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-3-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-3-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-3-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-3-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-3-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-3-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-3-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-3-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-3-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-3-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-3-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-3-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-3-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-3-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-3-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-3-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-3-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-3-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-3-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-3-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-3-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-3-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-4-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-4-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-4-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-4-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-4-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-4-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-4-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-4-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-4-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-4-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-4-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-4-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-4-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-4-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-4-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-4-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-4-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-4-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-4-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-4-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-4-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-4-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-4-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-4-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-4-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-4-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-4-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-4-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-4-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-4-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-4-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-4-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-4-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-4-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-4-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-4-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-4-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-4-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-4-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-4-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-4-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-4-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-4-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-4-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-4-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-4-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-4-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-4-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-4-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-4-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-4-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-4-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-4-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-4-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-4-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-4-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-4-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-4-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-5-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-5-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-5-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-5-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-5-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-5-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-5-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-5-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-5-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-5-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-5-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-5-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-5-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-5-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-5-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-5-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-5-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-5-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-5-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-5-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-5-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-5-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-5-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-5-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-5-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-5-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-5-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-5-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-5-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-5-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-5-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-5-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-5-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-5-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-5-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-5-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-5-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-5-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-5-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-5-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-5-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-5-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-5-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-5-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-5-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-5-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-5-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-5-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-5-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-5-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-5-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-5-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-5-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-5-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-5-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-5-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-5-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-5-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-6-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-6-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-6-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-6-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-6-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-6-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-6-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-6-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-6-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-6-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-6-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-6-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-6-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-6-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-6-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-6-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-6-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-6-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-6-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-6-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-6-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-6-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-6-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-6-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-6-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-6-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-6-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-6-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-6-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-6-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-6-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-6-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-6-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-6-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-6-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-6-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-6-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-6-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-6-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-6-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-6-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-6-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-6-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-6-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-6-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-6-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-6-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-6-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-6-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-6-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-6-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-6-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-6-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-6-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-6-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-6-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-6-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-6-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-7-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-7-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-7-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-7-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-7-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-7-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-7-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-7-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-7-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-7-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-7-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-7-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-7-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-7-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-7-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-7-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-7-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-7-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-7-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-7-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-7-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-7-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-7-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-7-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-7-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-7-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-7-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-7-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-7-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-7-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-7-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-7-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-7-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-7-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-7-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-7-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-7-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-7-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-7-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-7-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-7-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-7-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-7-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-7-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-7-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-7-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-7-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-7-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-7-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-7-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-7-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-7-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-7-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-7-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-7-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-7-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-7-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-7-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756

--- a/spark/core/pom.xml
+++ b/spark/core/pom.xml
@@ -1,37 +1,37 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-<parent>
-	<groupId>zingg</groupId>
-	<artifactId>zingg-spark</artifactId>
-	<version>${zingg.version}</version>
-</parent>
-		<artifactId>zingg-spark-core</artifactId>
-		<packaging>jar</packaging>
-<dependencies>
-	<dependency>
+	<parent>
 		<groupId>zingg</groupId>
-		<artifactId>zingg-spark-client</artifactId>
+		<artifactId>zingg-spark</artifactId>
 		<version>${zingg.version}</version>
-	</dependency>
-	<dependency>
-		<groupId>zingg</groupId>
-		<artifactId>zingg-common-core</artifactId>
-		<version>${zingg.version}</version>
-	</dependency>
-	<dependency>
-		<groupId>zingg</groupId>
-		<artifactId>zingg-common-client</artifactId>
-		<version>${zingg.version}</version>
-	</dependency>
+	</parent>
+	<artifactId>zingg-spark-core</artifactId>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>zingg</groupId>
+			<artifactId>zingg-spark-client</artifactId>
+			<version>${zingg.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>zingg</groupId>
+			<artifactId>zingg-common-core</artifactId>
+			<version>${zingg.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>zingg</groupId>
+			<artifactId>zingg-common-client</artifactId>
+			<version>${zingg.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>zingg</groupId>
 			<artifactId>zingg-common-core</artifactId>
 			<classifier>tests</classifier>
-			<type>test-jar</type>			
+			<type>test-jar</type>
 			<version>${zingg.version}</version>
 			<scope>test</scope>
-		</dependency>				
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
@@ -49,12 +49,72 @@
 			<artifactId>junit-jupiter-params</artifactId>
 			<version>5.8.1</version>
 			<scope>test</scope>
-		</dependency>	
-</dependencies>
-<build>
-		
-	
-			<plugins>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<profiles>
+		<profile>
+			<id>benchmark</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<id>run-benchmark</id>
+								<phase>integration-test</phase>
+								<goals><goal>exec</goal></goals>
+								<configuration>
+									<executable>java</executable>
+									<classpathScope>test</classpathScope>
+									<arguments>
+										<argument>-classpath</argument>
+										<classpath/>
+										<argument>org.openjdk.jmh.Main</argument>
+										<argument>BlockingTreeBenchmark</argument>
+										<argument>-rf</argument>
+										<argument>json</argument>
+										<argument>-rff</argument>
+										<argument>${project.build.directory}/benchmark-results.json</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	<build>
+
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.openjdk.jmh</groupId>
+							<artifactId>jmh-generator-annprocess</artifactId>
+							<version>1.37</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -66,8 +126,8 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>			
-			</plugins>
-		
-			</build>
+			</plugin>
+		</plugins>
+
+	</build>
 </project>

--- a/spark/core/src/main/java/zingg/spark/core/block/SparkBlock.java
+++ b/spark/core/src/main/java/zingg/spark/core/block/SparkBlock.java
@@ -9,6 +9,7 @@ import zingg.common.client.ZFrame;
 import zingg.common.client.util.ListMap;
 import zingg.common.core.block.Block;
 import zingg.common.core.block.FieldDefinitionStrategy;
+import zingg.common.core.block.HashUtility;
 import zingg.common.core.feature.FeatureFactory;
 import zingg.common.core.hash.HashFunction;
 import zingg.spark.core.feature.SparkFeatureFactory;
@@ -18,19 +19,25 @@ public class SparkBlock extends Block<Dataset<Row>, Row, Column, DataType> {
     private static final long serialVersionUID = 1L;
 
 
-	public SparkBlock(){
+    public SparkBlock(){
         super();
     }
-    
+
 
     public SparkBlock(ZFrame<Dataset<Row>, Row, Column> training, ZFrame<Dataset<Row>, Row, Column> dupes,
                       ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap, long maxSize, FieldDefinitionStrategy<Row> fieldDefinitionStrategy) {
-		super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy);
-	}
-    
+        super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy);
+    }
+
+    public SparkBlock(ZFrame<Dataset<Row>, Row, Column> training, ZFrame<Dataset<Row>, Row, Column> dupes,
+                      ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap, long maxSize,
+                      FieldDefinitionStrategy<Row> fieldDefinitionStrategy, HashUtility hashUtility) {
+        super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy, hashUtility);
+    }
+
     @Override
     public FeatureFactory<DataType> getFeatureFactory() {
         return new SparkFeatureFactory();
-    }    
+    }
 
 }

--- a/spark/core/src/main/java/zingg/spark/core/hash/SparkHashFunction.java
+++ b/spark/core/src/main/java/zingg/spark/core/hash/SparkHashFunction.java
@@ -15,10 +15,10 @@ import zingg.common.core.hash.HashFunction;
 
 
 public abstract class SparkHashFunction<T1, R> extends HashFunction<Dataset<Row>,Row,Column,DataType> implements UDF1<T1, R>{
-	
-	public static final Log LOG = LogFactory.getLog(SparkHashFunction.class);
-	
-	private BaseHash<T1, R> baseHash;
+
+    public static final Log LOG = LogFactory.getLog(SparkHashFunction.class);
+
+    private BaseHash<T1, R> baseHash;
 
     public BaseHash<T1, R> getBaseHash() {
         return baseHash;
@@ -28,16 +28,16 @@ public abstract class SparkHashFunction<T1, R> extends HashFunction<Dataset<Row>
         this.baseHash = baseHash;
         this.setName(baseHash.getName());
     }
-	
-	@Override
-	public R call(T1 t1) {
-	    return getBaseHash().call(t1);
-	}
-	
+
+    @Override
+    public R call(T1 t1) {
+        return getBaseHash().call(t1);
+    }
+
 
     @Override
     public ZFrame<Dataset<Row>, Row, Column> apply(ZFrame<Dataset<Row>, Row, Column> ds, String column,
-            String newColumn) {
+                                                   String newColumn) {
         return ds.withColumn(newColumn, functions.callUDF(this.name, ds.col(column)));
     }
 
@@ -55,7 +55,13 @@ public abstract class SparkHashFunction<T1, R> extends HashFunction<Dataset<Row>
     @Override
     public Object apply(Row r, String column) {
         return call((T1)getAs(r, column));
-   }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object applyToValue(Object value) {
+        return call((T1) value);
+    }
 
 
     @Override
@@ -77,6 +83,6 @@ public abstract class SparkHashFunction<T1, R> extends HashFunction<Dataset<Row>
         setDataType((DataType)ois.readObject());
         setReturnType((DataType)ois.readObject());
     }*/
-		
+
 
 }

--- a/spark/core/src/test/java/zingg/spark/core/block/BlockingTreeBenchmark.java
+++ b/spark/core/src/test/java/zingg/spark/core/block/BlockingTreeBenchmark.java
@@ -1,0 +1,244 @@
+package zingg.spark.core.block;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import zingg.common.client.FieldDefinition;
+import zingg.common.client.MatchTypes;
+import zingg.common.client.ZinggClientException;
+import zingg.common.client.ZFrame;
+import zingg.common.client.arguments.ArgumentServiceImpl;
+import zingg.common.client.arguments.model.Arguments;
+import zingg.common.client.arguments.model.IArguments;
+import zingg.common.client.util.IWithSession;
+import zingg.common.client.util.ListMap;
+import zingg.common.client.util.WithSession;
+import zingg.common.core.block.Canopy;
+import zingg.common.core.block.DefaultFieldDefinitionStrategy;
+import zingg.common.core.block.FieldDefinitionStrategy;
+import zingg.common.core.block.HashUtility;
+import zingg.common.core.block.Tree;
+import zingg.common.core.block.data.DataUtility;
+import zingg.common.core.block.model.Customer;
+import zingg.common.core.block.model.CustomerDupe;
+import zingg.common.core.hash.HashFunction;
+import zingg.common.core.util.CsvReader;
+import zingg.common.core.util.Heuristics;
+import zingg.spark.client.SparkClient;
+import zingg.spark.client.util.SparkDFObjectUtil;
+import zingg.spark.core.util.SparkHashUtil;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark comparing the original getBestNode algorithm against the
+ * optimized one (precomputed field values + early-exit + deferred buildDupeRemaining).
+ * Both benchmarks use HashUtility.CACHED so the only variable is the algorithm.
+ *
+ * Run via Maven:
+ *   mvn test-compile exec:exec -Pbenchmark -pl spark/core
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 2, batchSize = 1)
+@Measurement(iterations = 5, batchSize = 1)
+public class BlockingTreeBenchmark {
+
+    private static final String DATA_DIR = "testFebrl";
+    private static final String LARGE_CSV = DATA_DIR + "/test_large.csv";
+    private static final String LARGE_CONFIG = DATA_DIR + "/config_large.json";
+
+    private ZFrame<Dataset<Row>, Row, Column> sample;
+    private ZFrame<Dataset<Row>, Row, Column> positives;
+    private ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions;
+    private long blockSize;
+    private List<FieldDefinition> fieldDefinitions;
+
+    // Pre-collected lists so each invocation creates a fresh Canopy without
+    // triggering a Spark action (collectAsList is done once in setup).
+    private List<Row> trainingList;
+    private List<Row> positivesList;
+
+    private SparkSession spark;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception, ZinggClientException {
+        spark = SparkSession.builder()
+                .master("local[*]")
+                .appName("ZinggBlockingTreeBenchmark")
+                .config("spark.driver.bindAddress", "127.0.0.1")
+                .config("spark.driver.host", "127.0.0.1")
+                .getOrCreate();
+
+        new SparkClient().checkAndSetCheckpoint(spark);
+
+        IWithSession<SparkSession> withSession = new WithSession<>();
+        withSession.setSession(spark);
+        SparkDFObjectUtil dfObjectUtil = new SparkDFObjectUtil(withSession);
+
+        DataUtility dataUtility = new DataUtility(new CsvReader());
+        List<Customer> customers = dataUtility.getCustomers(LARGE_CSV);
+        List<CustomerDupe> customerDupes = dataUtility.getCustomerDupes(LARGE_CSV, false);
+
+        ZFrame<Dataset<Row>, Row, Column> zFrameTest =
+                dfObjectUtil.getDFFromObjectList(customers, Customer.class);
+        ZFrame<Dataset<Row>, Row, Column> zFramePositives =
+                dfObjectUtil.getDFFromObjectList(customerDupes, CustomerDupe.class);
+
+        InputStream configStream = Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream(LARGE_CONFIG),
+                "Config resource not found: " + LARGE_CONFIG
+        );
+        Path tempConfig = Files.createTempFile("zingg-config-", ".json");
+        tempConfig.toFile().deleteOnExit();
+        Files.copy(configStream, tempConfig, StandardCopyOption.REPLACE_EXISTING);
+        IArguments args = new ArgumentServiceImpl<>(Arguments.class).loadArguments(tempConfig.toString());
+
+        sample = zFrameTest.sample(false, 1.0);
+        long totalCount = sample.count();
+        blockSize = Heuristics.getMaxBlockSize(totalCount, args.getBlockSize());
+        positives = zFramePositives.coalesce(1);
+
+        hashFunctions = new SparkHashUtil(spark).getHashFunctionList();
+        fieldDefinitions = getActiveFieldDefinitions(args);
+
+        trainingList = sample.collectAsList();
+        positivesList = positives.collectAsList();
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        if (spark != null) {
+            spark.stop();
+            spark = null;
+        }
+    }
+
+    /** Optimized getBestNode: precomputed field values, early exit, deferred buildDupeRemaining. */
+    @Benchmark
+    public Tree<Canopy<Row>> optimizedAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    /** Original getBestNode: calls estimateElimCount() per candidate, builds dupeRemaining for all. */
+    @Benchmark
+    public Tree<Canopy<Row>> originalAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new OriginalAlgoBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+
+    private List<FieldDefinition> getActiveFieldDefinitions(IArguments args) {
+        List<FieldDefinition> active = new ArrayList<>();
+        for (FieldDefinition def : args.getFieldDefinition()) {
+            if (!(def.getMatchType() == null || def.getMatchType().contains(MatchTypes.DONT_USE))) {
+                active.add(def);
+            }
+        }
+        return active;
+    }
+
+    /**
+     * SparkBlock subclass that routes getBestNode to the pre-optimization algorithm
+     * (estimateElimCount per candidate, dupeRemaining built for all) so both
+     * original and optimized paths can be benchmarked under the same utility.
+     */
+    /** Precomputed values + no estimateCanopies, but early exit disabled (limit=MAX_VALUE). */
+    @Benchmark
+    public Tree<Canopy<Row>> noEarlyExitAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new NoEarlyExitAlgoBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    /** Original row extraction (function.apply per row) + early exit. No precomputed values. */
+    @Benchmark
+    public Tree<Canopy<Row>> originalEarlyExitAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new OriginalEarlyExitAlgoBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    private static class OriginalEarlyExitAlgoBlock extends SparkBlock {
+        OriginalEarlyExitAlgoBlock(ZFrame<Dataset<Row>, Row, Column> training,
+                                   ZFrame<Dataset<Row>, Row, Column> dupes,
+                                   ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap,
+                                   long maxSize,
+                                   FieldDefinitionStrategy<Row> fieldDefinitionStrategy,
+                                   HashUtility hashUtility) {
+            super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy, hashUtility);
+        }
+
+        @SuppressWarnings("unused")
+        public Canopy<Row> getBestNode(Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                List<FieldDefinition> fieldsOfInterest) throws Exception {
+            return getBestNodeOriginalEarlyExit(tree, parent, node, fieldsOfInterest);
+        }
+    }
+
+    private static class NoEarlyExitAlgoBlock extends SparkBlock {
+        NoEarlyExitAlgoBlock(ZFrame<Dataset<Row>, Row, Column> training,
+                             ZFrame<Dataset<Row>, Row, Column> dupes,
+                             ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap,
+                             long maxSize,
+                             FieldDefinitionStrategy<Row> fieldDefinitionStrategy,
+                             HashUtility hashUtility) {
+            super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy, hashUtility);
+        }
+
+        @SuppressWarnings("unused")
+        public Canopy<Row> getBestNode(Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                List<FieldDefinition> fieldsOfInterest) throws Exception {
+            return getBestNodeNoEarlyExit(tree, parent, node, fieldsOfInterest);
+        }
+    }
+
+    private static class OriginalAlgoBlock extends SparkBlock {
+
+        OriginalAlgoBlock(ZFrame<Dataset<Row>, Row, Column> training,
+                          ZFrame<Dataset<Row>, Row, Column> dupes,
+                          ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap,
+                          long maxSize,
+                          FieldDefinitionStrategy<Row> fieldDefinitionStrategy,
+                          HashUtility hashUtility) {
+            super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy, hashUtility);
+        }
+
+        @SuppressWarnings("unused")
+        public Canopy<Row> getBestNode(Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                List<FieldDefinition> fieldsOfInterest) throws Exception {
+            return getBestNodeOriginal(tree, parent, node, fieldsOfInterest);
+        }
+    }
+
+}

--- a/spark/core/src/test/java/zingg/spark/core/block/TestSparkBlockingTreeUtil.java
+++ b/spark/core/src/test/java/zingg/spark/core/block/TestSparkBlockingTreeUtil.java
@@ -6,14 +6,20 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataType;
 import org.junit.jupiter.api.extension.ExtendWith;
+import zingg.common.client.FieldDefinition;
 import zingg.common.client.ZFrame;
 import zingg.common.client.util.DFObjectUtil;
 import zingg.common.client.util.IWithSession;
 import zingg.common.client.util.ListMap;
 import zingg.common.client.util.WithSession;
 import zingg.common.core.block.Block;
+import zingg.common.core.block.Canopy;
 import zingg.common.core.block.DefaultFieldDefinitionStrategy;
+import zingg.common.core.block.HashUtility;
 import zingg.common.core.block.TestBlockingTreeUtil;
+import zingg.common.core.block.Tree;
+
+import java.util.List;
 import zingg.common.core.hash.HashFunction;
 import zingg.common.core.util.BlockingTreeUtil;
 import zingg.common.core.util.HashUtil;
@@ -56,5 +62,21 @@ public class TestSparkBlockingTreeUtil extends TestBlockingTreeUtil<SparkSession
     @Override
     protected Block<Dataset<Row>, Row, Column, DataType> getBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize) {
         return new SparkBlock(sample, positives, hashFunctions, blockSize, new DefaultFieldDefinitionStrategy<Row>());
+    }
+
+    @Override
+    protected Block<Dataset<Row>, Row, Column, DataType> getBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize, HashUtility hashUtility) {
+        return new SparkBlock(sample, positives, hashFunctions, blockSize, new DefaultFieldDefinitionStrategy<Row>(), hashUtility);
+    }
+
+    @Override
+    protected Block<Dataset<Row>, Row, Column, DataType> getOriginalAlgoBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize) {
+        return new SparkBlock(sample, positives, hashFunctions, blockSize, new DefaultFieldDefinitionStrategy<Row>(), HashUtility.CACHED) {
+            @Override
+            public Canopy<Row> getBestNode(Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                                           List<FieldDefinition> fieldsOfInterest) throws Exception {
+                return getBestNodeOriginal(tree, parent, node, fieldsOfInterest);
+            }
+        };
     }
 }

--- a/spark/core/src/test/resources/testFebrl/config_large.json
+++ b/spark/core/src/test/resources/testFebrl/config_large.json
@@ -1,0 +1,95 @@
+{
+	"fieldDefinition":[
+		{
+			"fieldName" : "id",
+			"matchType" : "dont_use",
+			"fields" : "fname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "fname",
+			"matchType" : "fuzzy",
+			"fields" : "fname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "lname",
+			"matchType" : "fuzzy",
+			"fields" : "lname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "stNo",
+			"matchType": "exact",
+			"fields" : "stNo",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "add1",
+			"matchType": "fuzzy",
+			"fields" : "add1",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "add2",
+			"matchType": "fuzzy",
+			"fields" : "add2",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "city",
+			"matchType": "fuzzy",
+			"fields" : "city",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "areacode",
+			"matchType": "exact",
+			"fields" : "areacode",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "state",
+			"matchType": "exact",
+			"fields" : "state",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "dob",
+			"matchType": "exact",
+			"fields" : "dob",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "ssn",
+			"matchType": "exact",
+			"fields" : "ssn",
+			"dataType": "string"
+		}
+		],
+		"output" : [{
+			"name":"output",
+			"format":"csv",
+			"props": {
+				"path": "/tmp/testFebrl/zinggOutput",
+				"delimiter": ",",
+				"header":true
+			}
+		}],
+		"data" : [{
+			"name":"test",
+			"format":"csv",
+			"props": {
+				"path": "./testFebrl/test_large.csv",
+				"delimiter": ",",
+				"header":false
+			},
+			"schema": "id string, fname string, lname string, stNo string, add1 string, add2 string, city string, state string, areacode string, dob string, ssn  string"
+			}
+		],
+		"labelDataSampleSize" : 0.5,
+		"numPartitions":4,
+		"modelId": 100,
+		"zinggDir": "./testFebrl/models"
+
+}


### PR DESCRIPTION
Command to run benchmarks:         mvn integration-test -Pbenchmark -pl spark/core -am -DskipTests     
Output file path:                             zingg/spark/core/target/benchmark-results.json

In this optimization we are trying to reduce the expensive calls to spark by storing the values calculated once, but this will take a lot of memory.








Optimizations that i tried - 
1. Reuse a probe Canopy instead of allocating per candidate
getNodeFromCurrent runs for every (field × function) candidate — with 10 fields × N functions that's potentially 50+ new Canopy + copyTo calls per getBestNode invocation, all immediately discarded. Only the winner needs a real object.

Fix: allocate one probe Canopy at the start of getBestNode, set function and context on it per iteration (both are just field assignments from copyTo), then countEliminationsWithValues and estimateCanopies run on it. Only when a new best is found, materialize a real Canopy with getNodeFromCurrent. This cuts N allocations per call down to 1.

2. Pass precomputed values into buildDupeRemaining
buildDupeRemaining calls function.apply(r, context.fieldName) per row — full row field extraction — even though getBestNode already has preVals1/preVals2 for that exact field. The problem is those arrays are local to the field loop and buildDupeRemaining is called after the loop ends, when the winning field's preVals are out of scope.

Fix: when a new best is found inside the loop, snapshot bestPreVals1 and bestPreVals2 alongside it. Pass them to buildDupeRemaining so it can call function.applyToValue(bestPreVals1[i]) instead of function.apply(r, fieldName) — same savings as countEliminationsWithValues already gets.

3. Fuse estimateCanopies + getCanopies
estimateCanopies iterates all of training, hashes each row, builds a HashSet → returns count, discards the set. Then getCanopies iterates all of training again, hashes each row a second time, builds a ListMap<hash, rows>.

For the winner these are two full passes over training computing identical hash values. If estimateCanopies instead built the full ListMap and cached it on the canopy, then getCanopies could return the cached result directly — saving one training scan per tree node expansion. The only cost is slightly higher memory for the winning candidate while getBestNode finishes (the non-winners still build only a HashSet).

4. Adaptive field ordering
The early-exit at least == 0 (and the > limit in countEliminationsWithValues) only pays off if a strong candidate appears early. With fields evaluated in config order, you might process 7 weak fields before hitting the best one.

Fix: maintain a Map<String, Long> avgElimByField updated after each getBestNode call. Sort adjustedFieldOfInterestList by descending average elimination count before the loop. This costs one sort per getBestNode call but pays back by making least drop faster, which causes more early exits in the tail of the candidate list. No change to correctness, low implementation risk.

Combined impact: (1) + (2) together eliminate the biggest source of garbage in the hot loop. (3) saves a full training scan per tree node. (4) amplifies the early-exit that's already in place. All four are single-threaded improvements — they'd stack on top of any parallelization you add later.
