### PR TITLE
blockingTree performance improvements - Added benchmarks for different optimisations

### DIFF
--- a/common/core/src/main/java/zingg/common/core/block/Block.java
+++ b/common/core/src/main/java/zingg/common/core/block/Block.java
@@ -23,6 +23,7 @@ public abstract class Block<D,R,C,T> implements Serializable {
 	public static final Log LOG = LogFactory.getLog(Block.class);
 	private final IHashFunctionUtility<D, R, C, T> hashFunctionUtility;
 	private FieldDefinitionStrategy<R> fieldDefinitionStrategy;
+	private GetBestNode<D, R, C, T> getBestNodeStrategy = new GetBestNode<>();
 
 	protected ZFrame<D,R,C> dupes;
 	// Class[] types;
@@ -54,6 +55,20 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		this.maxSize = maxSize;
 		this.fieldDefinitionStrategy = fieldDefinitionStrategy;
 	}
+
+	@SuppressWarnings("unchecked")
+	public Block(ZFrame<D, R, C> training, ZFrame<D, R, C> dupes,
+				 ListMap<T, HashFunction<D, R, C, T>> functionsMap, long maxSize,
+				 FieldDefinitionStrategy<R> fieldDefinitionStrategy, HashUtility hashUtility) {
+		this.hashFunctionUtility = HashFunctionUtilityFactory.getHashFunctionUtility(hashUtility);
+		this.training = training;
+		this.dupes = dupes;
+		this.childless = new ListMap<HashFunction<D, R, C, T>, String>();
+		this.functionsMap = functionsMap;
+		this.maxSize = maxSize;
+		this.fieldDefinitionStrategy = fieldDefinitionStrategy;
+	}
+
 
 	/**
 	 * @return the dupes
@@ -124,92 +139,19 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		c.estimateElimCount();
 	}
 
-	public Canopy<R>getBestNode(Tree<Canopy<R>> tree, Canopy<R>parent, Canopy<R>node,
-			List<FieldDefinition> fieldsOfInterest) throws Exception {
-		long least = Long.MAX_VALUE;
-		int maxElimination = 0;
-		Canopy<R>best = null;
-		List<FieldDefinition> adjustedFieldOfInterestList = getFieldOfInterestList(fieldsOfInterest, node);
-		for (FieldDefinition field : adjustedFieldOfInterestList) {
-			if (LOG.isDebugEnabled()){
-				LOG.debug("Trying for " + field + " with data type " + field.getDataType() + " and real dt " 
-					+ getFeatureFactory().getDataTypeFromString(field.getDataType()));
-			}
-			//Class type = FieldClass.getFieldClassClass(field.getFieldClass());
-			FieldDefinition context = field;
-			if (least ==0) break;//how much better can it get?
-			// applicable functions
-			List<HashFunction<D,R,C,T>> functions = functionsMap.get(getFeatureFactory().getDataTypeFromString(field.getDataType()));
-			if (LOG.isDebugEnabled()){
-				LOG.debug("functions are " + functions);
-			}
-			
-			if (functions != null) {
-				
-				for (HashFunction function : functions) {
-					// /if (!used.contains(field.getIndex(), function) &&
-					if (least ==0) break;//how much better can it get?
-					if (!hashFunctionUtility.isHashFunctionUsed(field, function, tree, node) //&&
-							//!childless.contains(function, field.fieldName)
-							) 
-							{
-						if (LOG.isDebugEnabled()){
-							LOG.debug("Evaluating field " + field.fieldName
-								+ " and function " + function + " for " + field.dataType);
-						}
-						Canopy<R>trial = getNodeFromCurrent(node, function,
-								context);
-						estimateElimCount(trial, least);
-						long elimCount = trial.getElimCount();
-
-						
-						//int trSize = (int) Math.ceil(0.02d * node.dupeN.count());
-						//boolean isNotEliminatingMoreThan1Percent = elimCount <= trSize ? true
-						//		: false;
-
-						if (LOG.isDebugEnabled()) {
-							LOG.debug("Elim Count is " + elimCount
-						
-								+ " ,least is "
-								+ least
-								//+ " , training is "
-								//+ node.training
-								+ ", dupe count " + node.dupeN.size());
-						}
-						if (least > elimCount) {
-							long childrenSize = trial.estimateCanopies();
-							if (childrenSize > 1) {
-						
-								// && isNotEliminatingMoreThan1Percent) {
-								if (LOG.isDebugEnabled()) {
-									LOG.debug("Yes, this fn has potential " + function);
-								}
-								least = elimCount;
-								best = trial;
-								best.elimCount = least;
-								/*if (elimCount == 0) {
-									LOG.debug("Out of this tyranny " + function);
-									break;
-								}*/
-							}
-							else {
-								if (LOG.isDebugEnabled()){
-									LOG.debug("No child " + function);
-								}
-								//childless.add(function, field.fieldName);
-							}
-							
-						}
-					}
-				}
-			}
-			else {
-				LOG.debug("functions are null??????");
-			}
-		}
-		return best;
-
+	public Canopy<R> getBestNode(Tree<Canopy<R>> tree, Canopy<R> parent, Canopy<R> node,
+								 List<FieldDefinition> fieldsOfInterest) throws Exception {
+		return getBestNodeStrategy.getBestNode(this, tree, parent, node, fieldsOfInterest);
 	}
+
+	public void setGetBestNodeStrategy(GetBestNode<D, R, C, T> strategy) {
+		this.getBestNodeStrategy = strategy;
+	}
+
+	public GetBestNode<D, R, C, T> getGetBestNodeStrategy() {
+		return getBestNodeStrategy;
+	}
+
 
 	/**
 	 * Holy Grail of Standalone
@@ -287,9 +229,10 @@ public abstract class Block<D,R,C,T> implements Serializable {
 		return tree;
 	}
 
-//	public boolean isFunctionUsed(FieldDefinition fieldDefinition, HashFunction<D, R, C, T> function) {
-//		return hashFunctionsInCurrentNodePath.contains(getKey(fieldDefinition, function));
-//	}
+	boolean isHashFunctionUsed(FieldDefinition field, HashFunction<D, R, C, T> function,
+							   Tree<Canopy<R>> tree, Canopy<R> node) {
+		return hashFunctionUtility.isHashFunctionUsed(field, function, tree, node);
+	}
 
 	public List<Canopy<R>> getHashSuccessors(Collection<Canopy<R>> successors, Object hash) {
 		List<Canopy<R>> retCanopy = new ArrayList<Canopy<R>>();

--- a/common/core/src/main/java/zingg/common/core/block/Canopy.java
+++ b/common/core/src/main/java/zingg/common/core/block/Canopy.java
@@ -313,4 +313,45 @@ public class Canopy<R> implements Serializable {
 		this.dupeRemaining = null;
 	}
 
+	public void buildDupeRemaining() {
+		dupeRemaining = new ArrayList<>(dupeN.size());
+		for (R r : dupeN) {
+			Object hash1 = function.apply(r, context.fieldName);
+			Object hash2 = function.apply(r, ColName.COL_PREFIX + context.fieldName);
+			if ((hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2))) {
+				dupeRemaining.add(r);
+			}
+		}
+		elimCount = dupeN.size() - dupeRemaining.size();
+	}
+
+	public long countEliminationsWithValues(Object[] preVals1, Object[] preVals2, long earlyExitThreshold) {
+		long count = 0;
+		for (int i = 0; i < dupeN.size(); i++) {
+			Object hash1 = function.applyToValue(preVals1[i]);
+			Object hash2 = function.applyToValue(preVals2[i]);
+			boolean survives = (hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2));
+			if (!survives) {
+				count++;
+				if (count >= earlyExitThreshold) return count;
+			}
+		}
+		return count;
+	}
+
+	public void buildDupeRemainingWithValues(Object[] preVals1, Object[] preVals2) {
+		dupeRemaining = new ArrayList<>(dupeN.size());
+		for (int i = 0; i < dupeN.size(); i++) {
+			Object hash1 = function.applyToValue(preVals1[i]);
+			Object hash2 = function.applyToValue(preVals2[i]);
+			if ((hash1 == null && hash2 == null) ||
+					(hash1 != null && hash2 != null && hash1.equals(hash2))) {
+				dupeRemaining.add(dupeN.get(i));
+			}
+		}
+		elimCount = dupeN.size() - dupeRemaining.size();
+	}
+
 }

--- a/common/core/src/main/java/zingg/common/core/block/GetBestNode.java
+++ b/common/core/src/main/java/zingg/common/core/block/GetBestNode.java
@@ -1,0 +1,279 @@
+package zingg.common.core.block;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import zingg.common.client.FieldDefinition;
+import zingg.common.client.util.ColName;
+import zingg.common.core.hash.HashFunction;
+
+/**
+ * Encapsulates all getBestNode algorithm variants. Inject an instance into Block
+ * so new variants can be added here without touching Block or Canopy.
+ *
+ * Block delegates its getBestNode call to whichever method is wired up via
+ * setAlgorithm / subclassing.
+ */
+public class GetBestNode<D, R, C, T> implements Serializable {
+
+    public static final Log LOG = LogFactory.getLog(GetBestNode.class);
+
+    /**
+     * Default entry point called by Block. Override in a subclass to switch
+     * algorithms without modifying Block.
+     */
+    public Canopy<R> getBestNode(Block<D, R, C, T> block, Tree<Canopy<R>> tree, Canopy<R> parent,
+                                  Canopy<R> node, List<FieldDefinition> fieldsOfInterest) throws Exception {
+        return optimized(block, tree, parent, node, fieldsOfInterest);
+    }
+
+    /**
+     * Precomputed field values + early-exit counting + deferred buildDupeRemaining.
+     * This is the production algorithm.
+     */
+    public Canopy<R> optimized(Block<D, R, C, T> block, Tree<Canopy<R>> tree, Canopy<R> parent,
+                                Canopy<R> node, List<FieldDefinition> fieldsOfInterest) throws Exception {
+        long least = Long.MAX_VALUE;
+        Canopy<R> best = null;
+        Map<T, List<HashFunction<D, R, C, T>>> functionsMap = block.getFunctionsMap();
+        List<FieldDefinition> adjustedFields = block.getFieldOfInterestList(fieldsOfInterest, node);
+
+        for (FieldDefinition field : adjustedFields) {
+            if (least == 0) break;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Trying for " + field + " with data type " + field.getDataType()
+                        + " and real dt " + block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            }
+            List<HashFunction<D, R, C, T>> functions =
+                    functionsMap.get(block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("functions are " + functions);
+            }
+            if (functions != null && !functions.isEmpty()) {
+                List<R> dupeN = node.getDupeN();
+                Object[] preVals1 = new Object[dupeN.size()];
+                Object[] preVals2 = new Object[dupeN.size()];
+                HashFunction<D, R, C, T> refFn = functions.get(0);
+                for (int i = 0; i < dupeN.size(); i++) {
+                    preVals1[i] = refFn.getAs(dupeN.get(i), field.fieldName);
+                    preVals2[i] = refFn.getAs(dupeN.get(i), ColName.COL_PREFIX + field.fieldName);
+                }
+                for (HashFunction<D, R, C, T> function : functions) {
+                    if (least == 0) break;
+                    if (!block.isHashFunctionUsed(field, function, tree, node)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Evaluating field " + field.fieldName + " and function "
+                                    + function + " for " + field.dataType);
+                        }
+                        Canopy<R> trial = block.getNodeFromCurrent(node, function, field);
+                        long elimCount = trial.countEliminationsWithValues(preVals1, preVals2, least);
+                        trial.elimCount = elimCount;
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Elim Count is " + elimCount + " ,least is " + least
+                                    + ", dupe count " + node.dupeN.size());
+                        }
+                        if (least > elimCount && (elimCount > 0 || trial.estimateCanopies() > 1)) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Yes, this fn has potential " + function);
+                            }
+                            least = elimCount;
+                            best = trial;
+                            best.elimCount = least;
+                        }
+                    }
+                }
+            } else {
+                LOG.debug("functions are null??????");
+            }
+        }
+        if (best != null) {
+            best.buildDupeRemaining();
+        }
+        return best;
+    }
+
+    /**
+     * Original algorithm: estimateElimCount() per candidate, no early exit,
+     * buildDupeRemaining built for all evaluated trials.
+     */
+    public Canopy<R> original(Block<D, R, C, T> block, Tree<Canopy<R>> tree, Canopy<R> parent,
+                               Canopy<R> node, List<FieldDefinition> fieldsOfInterest) throws Exception {
+        long least = Long.MAX_VALUE;
+        Canopy<R> best = null;
+        Map<T, List<HashFunction<D, R, C, T>>> functionsMap = block.getFunctionsMap();
+        List<FieldDefinition> adjustedFields = block.getFieldOfInterestList(fieldsOfInterest, node);
+
+        for (FieldDefinition field : adjustedFields) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Trying for " + field + " with data type " + field.getDataType()
+                        + " and real dt " + block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            }
+            FieldDefinition context = field;
+            if (least == 0) break;
+            List<HashFunction<D, R, C, T>> functions =
+                    functionsMap.get(block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("functions are " + functions);
+            }
+            if (functions != null) {
+                for (HashFunction<D, R, C, T> function : functions) {
+                    if (least == 0) break;
+                    if (!block.isHashFunctionUsed(field, function, tree, node)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Evaluating field " + field.fieldName + " and function "
+                                    + function + " for " + field.dataType);
+                        }
+                        Canopy<R> trial = block.getNodeFromCurrent(node, function, context);
+                        block.estimateElimCount(trial, least);
+                        long elimCount = trial.getElimCount();
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Elim Count is " + elimCount + " ,least is " + least
+                                    + ", dupe count " + node.dupeN.size());
+                        }
+                        if (least > elimCount) {
+                            long childrenSize = trial.estimateCanopies();
+                            if (childrenSize > 1) {
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("Yes, this fn has potential " + function);
+                                }
+                                least = elimCount;
+                                best = trial;
+                                best.elimCount = least;
+                            } else {
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("No child " + function);
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                LOG.debug("functions are null??????");
+            }
+        }
+        return best;
+    }
+
+
+    /**
+     * Extends optimized() by passing the winning field's precomputed values directly
+     * to buildDupeRemaining. When a new best is found inside the field loop, its
+     * preVals1/preVals2 arrays are snapshotted alongside it. buildDupeRemainingWithValues
+     * then uses function.applyToValue(preVals[i]) instead of re-extracting via
+     * function.apply(row, fieldName) — eliminating the per-row field-extraction cost
+     * that buildDupeRemaining currently pays even though getBestNode already did it.
+     */
+    public Canopy<R> precomputedBuildDupeRemaining(Block<D, R, C, T> block, Tree<Canopy<R>> tree,
+                                                    Canopy<R> parent, Canopy<R> node,
+                                                    List<FieldDefinition> fieldsOfInterest) throws Exception {
+        long least = Long.MAX_VALUE;
+        Canopy<R> best = null;
+        Object[] bestPreVals1 = null;
+        Object[] bestPreVals2 = null;
+        Map<T, List<HashFunction<D, R, C, T>>> functionsMap = block.getFunctionsMap();
+        List<FieldDefinition> adjustedFields = block.getFieldOfInterestList(fieldsOfInterest, node);
+
+        for (FieldDefinition field : adjustedFields) {
+            if (least == 0) break;
+            List<HashFunction<D, R, C, T>> functions =
+                    functionsMap.get(block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            if (functions != null && !functions.isEmpty()) {
+                List<R> dupeN = node.getDupeN();
+                Object[] preVals1 = new Object[dupeN.size()];
+                Object[] preVals2 = new Object[dupeN.size()];
+                HashFunction<D, R, C, T> refFn = functions.get(0);
+                for (int i = 0; i < dupeN.size(); i++) {
+                    preVals1[i] = refFn.getAs(dupeN.get(i), field.fieldName);
+                    preVals2[i] = refFn.getAs(dupeN.get(i), ColName.COL_PREFIX + field.fieldName);
+                }
+                for (HashFunction<D, R, C, T> function : functions) {
+                    if (least == 0) break;
+                    if (!block.isHashFunctionUsed(field, function, tree, node)) {
+                        Canopy<R> trial = block.getNodeFromCurrent(node, function, field);
+                        long elimCount = trial.countEliminationsWithValues(preVals1, preVals2, least);
+                        trial.elimCount = elimCount;
+                        if (least > elimCount && (elimCount > 0 || trial.estimateCanopies() > 1)) {
+                            least = elimCount;
+                            best = trial;
+                            best.elimCount = least;
+                            bestPreVals1 = preVals1;
+                            bestPreVals2 = preVals2;
+                        }
+                    }
+                }
+            } else {
+                LOG.debug("functions are null??????");
+            }
+        }
+        if (best != null) {
+            best.buildDupeRemainingWithValues(bestPreVals1, bestPreVals2);
+        }
+        return best;
+    }
+
+    /**
+     * Probe-reuse optimisation: allocates one probe Canopy before the loop and
+     * reuses it for every (field × function) candidate by simply reassigning
+     * probe.function and probe.context. A real Canopy is materialised via
+     * getNodeFromCurrent only when a new best is found (typically 1–2 times per
+     * call). This cuts per-candidate Canopy + copyTo allocations from O(N) to O(1).
+     *
+     * Correctness: estimateCanopies() and countEliminationsWithValues() are pure
+     * reads — they only touch probe.function, probe.context, probe.training, and
+     * probe.dupeN, none of which change between iterations (dupeN/training come
+     * from node via copyTo at the start; function/context are set explicitly each
+     * time).
+     */
+    public Canopy<R> probeReuse(Block<D, R, C, T> block, Tree<Canopy<R>> tree, Canopy<R> parent,
+                                 Canopy<R> node, List<FieldDefinition> fieldsOfInterest) throws Exception {
+        long least = Long.MAX_VALUE;
+        Canopy<R> best = null;
+        Map<T, List<HashFunction<D, R, C, T>>> functionsMap = block.getFunctionsMap();
+        List<FieldDefinition> adjustedFields = block.getFieldOfInterestList(fieldsOfInterest, node);
+
+        // One probe Canopy shared across all candidates — no per-candidate allocation.
+        Canopy<R> probe = block.getCanopy();
+        node.copyTo(probe);
+
+        for (FieldDefinition field : adjustedFields) {
+            if (least == 0) break;
+            List<HashFunction<D, R, C, T>> functions =
+                    functionsMap.get(block.getFeatureFactory().getDataTypeFromString(field.getDataType()));
+            if (functions != null && !functions.isEmpty()) {
+                List<R> dupeN = node.getDupeN();
+                Object[] preVals1 = new Object[dupeN.size()];
+                Object[] preVals2 = new Object[dupeN.size()];
+                HashFunction<D, R, C, T> refFn = functions.get(0);
+                for (int i = 0; i < dupeN.size(); i++) {
+                    preVals1[i] = refFn.getAs(dupeN.get(i), field.fieldName);
+                    preVals2[i] = refFn.getAs(dupeN.get(i), ColName.COL_PREFIX + field.fieldName);
+                }
+                for (HashFunction<D, R, C, T> function : functions) {
+                    if (least == 0) break;
+                    if (!block.isHashFunctionUsed(field, function, tree, node)) {
+                        probe.function = function;
+                        probe.context = field;
+                        long elimCount = probe.countEliminationsWithValues(preVals1, preVals2, least);
+                        if (least > elimCount && (elimCount > 0 || probe.estimateCanopies() > 1)) {
+                            // Materialise a real Canopy only for the new best.
+                            Canopy<R> winner = block.getNodeFromCurrent(node, function, field);
+                            winner.elimCount = elimCount;
+                            best = winner;
+                            least = elimCount;
+                        }
+                    }
+                }
+            } else {
+                LOG.debug("functions are null??????");
+            }
+        }
+        if (best != null) {
+            best.buildDupeRemaining();
+        }
+        return best;
+    }
+}

--- a/common/core/src/main/java/zingg/common/core/hash/HashFunction.java
+++ b/common/core/src/main/java/zingg/common/core/hash/HashFunction.java
@@ -77,7 +77,13 @@ public abstract class HashFunction<D,R,C,T> implements Serializable{
 
 		public abstract Object apply(D df, R r, String column); // added for SnowFrame getAsString method
 
-		/* 
+		// Apply the hash transformation to an already-extracted field value.
+		// Separates extraction (getAs) from hashing so callers can precompute
+		// field values once per row and reuse them across multiple functions.
+		public abstract Object applyToValue(Object value);
+
+
+		/*
 		public abstract void writeCustomObject(ObjectOutputStream out) throws IOException;
 		public abstract void readCustomObject(ObjectInputStream ois) throws ClassNotFoundException, IOException;
 		

--- a/common/core/src/test/java/zingg/common/core/block/TestBlockingTreeUtil.java
+++ b/common/core/src/test/java/zingg/common/core/block/TestBlockingTreeUtil.java
@@ -2,8 +2,6 @@ package zingg.common.core.block;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import zingg.common.client.arguments.ArgumentServiceImpl;
 import zingg.common.client.arguments.model.Arguments;
 import zingg.common.client.FieldDefinition;
@@ -22,13 +20,11 @@ import zingg.common.core.util.CsvReader;
 import zingg.common.core.util.HashUtil;
 import zingg.common.core.util.Heuristics;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
-import static java.lang.Math.max;
-
 
 public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
 
@@ -36,7 +32,9 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     private int maxDepth = 1;
     private int totalNodes = 0;
     private static String TEST_FILE = "test.csv";
+    private static String LARGE_TEST_FILE = "test_large.csv";
     private static String CONFIG_FILE = "config.json";
+    private static String LARGE_CONFIG_FILE = "config_large.json";
     private final DataUtility dataUtility;
 
     public TestBlockingTreeUtil() {
@@ -71,10 +69,57 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     }
 
 
+    @Test
+    public void testOriginalAndOptimizedProduceSameTree() throws Exception, ZinggClientException {
+        setTestDataBaseLocation();
+        List<Customer> testCustomers = dataUtility.getCustomers(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE);
+        List<CustomerDupe> testCustomerDupes = dataUtility.getCustomerDupes(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE, false);
+        DFObjectUtil<S, D, R, C> dfObjectUtil = getDFObjectUtil();
+
+        ZFrame<D, R, C> zFrameTest = dfObjectUtil.getDFFromObjectList(testCustomers, Customer.class);
+        ZFrame<D, R, C> zFramePositives = dfObjectUtil.getDFFromObjectList(testCustomerDupes, CustomerDupe.class);
+
+        HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + LARGE_CONFIG_FILE)).toURI()).toString();
+        IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(configFile);
+
+        Tree<Canopy<R>> originalTree  = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "original");
+        Tree<Canopy<R>> optimizedTree = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(originalTree, optimizedTree, 1),
+                "Original and optimized getBestNode must produce identical blocking trees");
+    }
+
+    @Test
+    public void testLargeDeepBlockingTree() throws Exception, ZinggClientException {
+        setTestDataBaseLocation();
+        List<Customer> testCustomers = dataUtility.getCustomers(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE);
+        List<CustomerDupe> testCustomerDupes = dataUtility.getCustomerDupes(TEST_DATA_BASE_LOCATION + "/" + LARGE_TEST_FILE, false);
+        DFObjectUtil<S, D, R, C> dfObjectUtil = getDFObjectUtil();
+
+        ZFrame<D, R, C> zFrameTest = dfObjectUtil.getDFFromObjectList(testCustomers, Customer.class);
+        ZFrame<D, R, C> zFramePositives = dfObjectUtil.getDFFromObjectList(testCustomerDupes, CustomerDupe.class);
+
+        HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + LARGE_CONFIG_FILE)).toURI()).toString();
+        IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(configFile);
+
+        System.out.println("=== STARTING LARGE DEEP BLOCKING TREE TEST ===");
+        Tree<Canopy<R>> blockingTreeDefault = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "default");
+        Tree<Canopy<R>> blockingTreeCached = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(blockingTreeDefault, blockingTreeCached, 1));
+        System.out.println("-------- max depth of trees -------- " + maxDepth);
+        System.out.println("-------- total nodes in a trees ---- " + totalNodes);
+
+        maxDepth = 1; totalNodes = 0;
+        Tree<Canopy<R>> blockingTreeDefault2 = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "default");
+        Tree<Canopy<R>> blockingTreeCached2 = getBlockingTree(zFrameTest, zFramePositives, hashUtil, args, "cached");
+        Assertions.assertTrue(dfsSameTreeValidation(blockingTreeDefault2, blockingTreeCached2, 1));
+    }
+
     public void testSameBlockingTree(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives) throws Exception, ZinggClientException {
         setTestDataBaseLocation();
         HashUtil<S, D, R, C, T> hashUtil = getHashUtil();
-        String configFile = Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + CONFIG_FILE)).getFile();
+        String configFile = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(TEST_DATA_BASE_LOCATION + "/" + CONFIG_FILE)).toURI()).toString();
         IArguments args = new ArgumentServiceImpl<Arguments>(Arguments.class).loadArguments(
                 configFile);
         args.setBlockSize(8);
@@ -92,46 +137,42 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
 
 
     private Tree<Canopy<R>> getBlockingTree(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives, HashUtil<S, D, R, C, T> hashUtil,
-                                         IArguments args, String blockingTreeType) throws Exception, ZinggClientException {
-        long ts = System.currentTimeMillis();
+                                            IArguments args, String blockingTreeType) throws Exception, ZinggClientException {
         Block<D, R, C, T> block;
         if ("cached".equals(blockingTreeType)) {
             block = getCachedBasedBlock(zFrameTest, zFramePositives, hashUtil, args);
+        } else if ("original".equals(blockingTreeType)) {
+            block = getOriginalAlgoBlock(zFrameTest, zFramePositives, hashUtil, args);
         } else {
             block = getDefaultBlock(zFrameTest, zFramePositives, hashUtil, args);
         }
         Canopy<R> root = getCanopy(zFrameTest, zFramePositives, 1);
-        Tree<Canopy<R>> blockingTree = block.getBlockingTree(null, null, root, getFieldDefinitions(args));
-        System.out.println("************ time taken to create " + blockingTreeType + " blocking tree ************, " + (System.currentTimeMillis() - ts));
-        return blockingTree;
+        return block.getBlockingTree(null, null, root, getFieldDefinitions(args));
     }
 
-    //Override with new CacheBasedHashFunctionUtility<D, R, C, T>()
     private Block<D, R, C, T> getCachedBasedBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
                                                   HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
-        try (MockedStatic<HashFunctionUtilityFactory> hashFunctionUtilityFactoryMock = Mockito.mockStatic(HashFunctionUtilityFactory.class)) {
-            hashFunctionUtilityFactoryMock.when(() -> HashFunctionUtilityFactory.getHashFunctionUtility(Mockito.any(HashUtility.class)))
-                    .thenReturn(new CacheBasedHashFunctionUtility<D, R, C, T>());
-            return getBlock(zFrameTest, 1, zFramePositives, -1,
-                    hashUtil.getHashFunctionList(), arguments);
-        }
+        return getBlock(zFrameTest, 1, zFramePositives, -1, hashUtil.getHashFunctionList(), arguments, HashUtility.CACHED);
     }
 
-    //Override with new DefaultHashFunctionUtility<>()
+    private Block<D, R, C, T> getOriginalAlgoBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
+                                                   HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
+        ZFrame<D, R, C> sample = zFrameTest.sample(false, 1);
+        long totalCount = sample.count();
+        long blockSize = Heuristics.getMaxBlockSize(totalCount, arguments.getBlockSize());
+        ZFrame<D, R, C> positives = zFramePositives.coalesce(1);
+        return getOriginalAlgoBlock(sample, positives, hashUtil.getHashFunctionList(), blockSize);
+    }
+
     private Block<D, R, C, T> getDefaultBlock(ZFrame<D, R, C> zFrameTest, ZFrame<D, R, C> zFramePositives,
-                                                  HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
-        try (MockedStatic<HashFunctionUtilityFactory> hashFunctionUtilityFactoryMock = Mockito.mockStatic(HashFunctionUtilityFactory.class)) {
-            hashFunctionUtilityFactoryMock.when(() -> HashFunctionUtilityFactory.getHashFunctionUtility(Mockito.any(HashUtility.class)))
-                    .thenReturn(new DefaultHashFunctionUtility<D, R, C, T>());
-            return getBlock(zFrameTest, 1, zFramePositives, -1,
-                    hashUtil.getHashFunctionList(), arguments);
-        }
+                                              HashUtil<S, D, R, C, T> hashUtil, IArguments arguments) throws Exception {
+        return getBlock(zFrameTest, 1, zFramePositives, -1, hashUtil.getHashFunctionList(), arguments, HashUtility.DEFAULT);
     }
 
 
     private boolean dfsSameTreeValidation(Tree<Canopy<R>> node1, Tree<Canopy<R>> node2, int depth) {
         totalNodes++;
-        maxDepth = max(maxDepth, depth);
+        maxDepth = Math.max(maxDepth, depth);
 
         //if both the node1 and node2 are null, return true
         if(node1 == null && node2 == null){
@@ -198,13 +239,13 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     }
 
     private Block<D, R, C, T> getBlock(ZFrame<D, R, C> testData, double sampleFraction, ZFrame<D,R,C> positives,
-                                       long blockSize, ListMap<T, HashFunction<D,R,C,T>> hashFunctions, IArguments args) {
+                                       long blockSize, ListMap<T, HashFunction<D,R,C,T>> hashFunctions, IArguments args,
+                                       HashUtility hashUtility) {
         ZFrame<D,R,C> sample = testData.sample(false, sampleFraction);
         long totalCount = sample.count();
         if (blockSize == -1) blockSize = Heuristics.getMaxBlockSize(totalCount, args.getBlockSize());
         positives = positives.coalesce(1);
-        Block<D,R,C,T> cblock = getBlock(sample, positives, hashFunctions, blockSize);
-        return cblock;
+        return getBlock(sample, positives, hashFunctions, blockSize, hashUtility);
     }
 
     private Canopy<R> getCanopy(ZFrame<D,R,C> testData, ZFrame<D,R,C> positives, double sampleFraction) {
@@ -229,4 +270,9 @@ public abstract class TestBlockingTreeUtil<S, D, R, C, T> {
     protected abstract void setTestDataBaseLocation();
     protected abstract Block<D, R, C, T> getBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
                                                   ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize);
+    protected abstract Block<D, R, C, T> getBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
+                                                  ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize,
+                                                  HashUtility hashUtility);
+    protected abstract Block<D, R, C, T> getOriginalAlgoBlock(ZFrame<D,R,C> sample, ZFrame<D,R,C> positives,
+                                                              ListMap<T, HashFunction<D,R,C,T>>hashFunctions, long blockSize);
 }

--- a/common/core/src/test/java/zingg/common/core/util/CsvReader.java
+++ b/common/core/src/test/java/zingg/common/core/util/CsvReader.java
@@ -6,8 +6,9 @@ import com.opencsv.exceptions.CsvException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,14 @@ public class CsvReader implements ICsvReader {
         return records;
     }
 
-    private CSVReader getCSVReader(String source) throws IOException, URISyntaxException {
-        File file = new File(Objects.requireNonNull(this.getClass().getClassLoader().getResource(source)).toURI());
-        FileReader filereader = new FileReader(file);
-        CSVReader csvReader = new CSVReaderBuilder(filereader)
+    private CSVReader getCSVReader(String source) throws IOException {
+        InputStream is = Objects.requireNonNull(
+            this.getClass().getClassLoader().getResourceAsStream(source),
+            "Resource not found on classpath: " + source
+        );
+        return new CSVReaderBuilder(new InputStreamReader(is))
                 .withSkipLines(1)
                 .build();
-        return csvReader;
     }
 
 }

--- a/common/core/src/test/java/zingg/hash/TestHashFunction.java
+++ b/common/core/src/test/java/zingg/hash/TestHashFunction.java
@@ -36,6 +36,11 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
 
         String expectedName = "hashFunction";
@@ -67,6 +72,11 @@ public class TestHashFunction {
 
             @Override
             public Object apply(String s, Integer integer, String column) {
+                return null;
+            }
+
+            @Override
+            public Object applyToValue(Object value) {
                 return null;
             }
         };
@@ -107,6 +117,11 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
 
         Boolean isUdf = false;
@@ -141,10 +156,15 @@ public class TestHashFunction {
             public Object apply(String s, Integer integer, String column) {
                 return null;
             }
+
+            @Override
+            public Object applyToValue(Object value) {
+                return null;
+            }
         };
         Integer value = 10;
         String column = "inputColumn";
         assertEquals(null, hashFunction.getAs(value, column));
     }
-    
+
 }

--- a/common/core/src/test/resources/testFebrl/test_large.csv
+++ b/common/core/src/test/resources/testFebrl/test_large.csv
@@ -1,0 +1,520 @@
+rec-0-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-0-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-0-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-0-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-0-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-0-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-0-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-0-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-0-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-0-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-0-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-0-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-0-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-0-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-0-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-0-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-0-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-0-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-0-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-0-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-0-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-0-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-0-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-0-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-0-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-0-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-0-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-0-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-0-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-0-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-0-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-0-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-0-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-0-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-0-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-0-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-0-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-0-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-0-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-0-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-0-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-0-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-0-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-0-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-0-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-0-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-0-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-0-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-0-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-0-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-0-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-0-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-0-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-0-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-0-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-0-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-0-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-0-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-0-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-0-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-0-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-1-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-1-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-1-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-1-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-1-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-1-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-1-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-1-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-1-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-1-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-1-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-1-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-1-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-1-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-1-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-1-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-1-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-1-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-1-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-1-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-1-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-1-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-1-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-1-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-1-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-1-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-1-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-1-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-1-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-1-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-1-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-1-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-1-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-1-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-1-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-1-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-1-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-1-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-1-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-1-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-1-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-1-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-1-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-1-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-1-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-1-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-1-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-1-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-1-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-1-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-1-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-1-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-1-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-1-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-1-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-1-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-1-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-1-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-1-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-1-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-2-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-2-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-2-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-2-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-2-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-2-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-2-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-2-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-2-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-2-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-2-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-2-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-2-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-2-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-2-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-2-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-2-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-2-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-2-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-2-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-2-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-2-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-2-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-2-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-2-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-2-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-2-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-2-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-2-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-2-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-2-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-2-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-2-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-2-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-2-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-2-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-2-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-2-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-2-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-2-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-2-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-2-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-2-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-2-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-2-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-2-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-2-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-2-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-2-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-2-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-2-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-2-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-2-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-2-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-2-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-2-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-2-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-2-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-2-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-2-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-3-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-3-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-3-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-3-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-3-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-3-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-3-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-3-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-3-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-3-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-3-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-3-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-3-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-3-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-3-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-3-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-3-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-3-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-3-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-3-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-3-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-3-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-3-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-3-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-3-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-3-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-3-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-3-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-3-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-3-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-3-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-3-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-3-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-3-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-3-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-3-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-3-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-3-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-3-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-3-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-3-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-3-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-3-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-3-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-3-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-3-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-3-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-3-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-3-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-3-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-3-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-3-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-3-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-3-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-3-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-3-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-3-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-3-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-3-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-3-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-4-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-4-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-4-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-4-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-4-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-4-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-4-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-4-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-4-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-4-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-4-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-4-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-4-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-4-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-4-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-4-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-4-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-4-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-4-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-4-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-4-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-4-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-4-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-4-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-4-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-4-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-4-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-4-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-4-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-4-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-4-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-4-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-4-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-4-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-4-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-4-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-4-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-4-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-4-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-4-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-4-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-4-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-4-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-4-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-4-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-4-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-4-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-4-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-4-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-4-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-4-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-4-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-4-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-4-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-4-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-4-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-4-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-4-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-4-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-4-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-5-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-5-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-5-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-5-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-5-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-5-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-5-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-5-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-5-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-5-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-5-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-5-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-5-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-5-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-5-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-5-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-5-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-5-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-5-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-5-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-5-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-5-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-5-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-5-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-5-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-5-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-5-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-5-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-5-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-5-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-5-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-5-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-5-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-5-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-5-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-5-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-5-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-5-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-5-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-5-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-5-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-5-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-5-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-5-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-5-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-5-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-5-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-5-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-5-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-5-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-5-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-5-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-5-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-5-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-5-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-5-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-5-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-5-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-5-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-5-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-6-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-6-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-6-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-6-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-6-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-6-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-6-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-6-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-6-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-6-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-6-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-6-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-6-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-6-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-6-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-6-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-6-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-6-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-6-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-6-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-6-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-6-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-6-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-6-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-6-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-6-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-6-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-6-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-6-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-6-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-6-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-6-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-6-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-6-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-6-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-6-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-6-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-6-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-6-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-6-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-6-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-6-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-6-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-6-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-6-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-6-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-6-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-6-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-6-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-6-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-6-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-6-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-6-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-6-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-6-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-6-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-6-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-6-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-6-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-6-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1020-org, blake, ryan,4, starling place, berkeley vlge, marsden,5412, nsw,19271027,2402765
+rec-7-1021-dup-0, thomas, georgze,1, mcmanus place, , north turarmurra,3130, sa,19630225,5460534
+rec-7-1021-org, thomas, george,1, mcmanus place, stoney creek, north turramurra,3130, sa,19630225,5460534
+rec-7-1022-dup-1, jackson, eglinron,840, mountview, fowles treet, burlei gh heads,2803, sa,19830807,2932837
+rec-7-1022-dup-2, jackson, eglinton,840, fowles street, moun tvjiew, burleigh heads,2830, ss, ,2932837
+rec-7-1022-dup-3, jackson, christo,840, fowles street, mou ntveiw, burleig heads,2830, sa,19830807,2932837
+rec-7-1022-dup-4, jackson, eglinton,840, fowles street, mountv iew, burleigh heads,2830, sa,19830807,2932837
+rec-7-1022-org, jackson, eglinton,840, fowles street, mountview, burleigh heads,2830, sa,19830807,2932837
+rec-7-1023-org, gianni, matson,701, willis street, boonooloo, clifton,3101, vic,19410111,2540080
+rec-7-1024-org, takeisha, freeborn,6, suttor street, the groves street, wentworth falls,4615, vic,19620206,8111362
+rec-7-1025-org, emiily, britten,8, kitchener street, hilltop hostel rowethorpe, lake heights,2463, qld,19491021,9588775
+rec-7-1026-dup-0, xani, green, , phill ip avenue, , armidale,5108, nsw,19390410,9201057
+rec-7-1026-dup-1, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201857
+rec-7-1026-org, xani, green,2, phillip avenue, abbey green, armidale,5108, nsw,19390410,9201057
+rec-7-1027-org, nathan, smallacombe,20, guthridge crescent, red cross units, sandy bay,6056, sa,19241223,7522263
+rec-7-1028-dup-0, , ,24, , woorinyan, riverwood,3749, qld,19180205,9341716
+rec-7-1028-dup-1, , eglinton,24, curriecrescent, woorinyan, riverwood,3749, qld,19180205,1909717
+rec-7-1028-org, , eglinton,24, currie crescent, woorinyan, riverwood,3749, qld,19180205,9341716
+rec-7-1029-dup-0, kylee, stepehndon,81, rose scott circuit, cordobak anor, ashfield,4226, vic,19461101,4783085
+rec-7-1029-dup-1, sachin, stephenson,81, rose scott circuit, cordoba manor, ashfi eld,4226, vic,19461101,4783085
+rec-7-1029-dup-2, annalise, stephenson,81, rose scott circuit, cordoba manor, ashfoeld,4226, vic,19461101,4783085
+rec-7-1029-dup-3, kykee, turale,81, rose scott circuit, , ashfield,4226, vic,19461101,4783085
+rec-7-1029-dup-4, kylee, stephenson,81, cordoba manor, rose scott circuit, ashfield,4226, vic,19461101,4783085
+rec-7-1029-org, kylee, stephenson,81, rose scott circuit, cordoba manor, ashfield,4226, vic,19461101,4783085
+rec-7-103-dup-0, benjamin, koerbin,15, wybel anah, violet grover place, mill park,2446, nsw,19210210,3808808
+rec-7-103-org, briony, koerbin,146, violet grover place, wybelanah, mill park,2446, nsw,19210210,3808808
+rec-7-1030-org, emma, crossman,53, mcdowall place, kellhaven, tara,5608, vic,19391027,3561186
+rec-7-1031-org, samantha, sabieray,68, quandong street, wattle brae, gorokan,4019, wa,19590807,2863290
+rec-7-1032-dup-0, brooklyn, naar-cafentas,210, duffy street, tourist psrk, berwick,2481, nsw, ,3624304
+rec-7-1032-org, brooklyn, naar-cafentas,210, duffy street, tourist park, berwick,2481, nsw,19840802,3624304
+rec-7-1033-dup-0, keziah, painter,18, ainsli e avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-7-1033-org, keziah, painter,18, ainslie avenue, sec 1, torquay,3205, vic,19191031,7801066
+rec-7-1034-dup-0, erin, maynard,24, , wariala, little river,2777, vic,19970430,7429462
+rec-7-1034-dup-1, erin, maynard,51, wilshire street, warialda, little irver,2777, vic,19970430,1815999
+rec-7-1034-dup-2, hayley, maynard,14, wilshire street, , little river,2777, vic,19970430,7429462
+rec-7-1034-org, erin, maynard,14, wilshire street, warialda, little river,2777, vic,19970430,7429462
+rec-7-1035-dup-0, jaiden, rollins,48, tulgeywood, rossarden street, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-1, jaiden, rollins,95, rossarden street, tulgewyood, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-2, jaiden, rolilns,48, swinden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-7-1035-dup-3, jaiden, rolli ns,48, tulgeywomod, rossarden street, balwyn north,2224, nf,19280722,7626396
+rec-7-1035-org, jaiden, rollins,48, rossarden street, tulgeywood, balwyn north,2224, nt,19280722,7626396
+rec-7-1036-dup-0, , held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-7-1036-dup-1, sarsha, held,42, lampard circuit, , golden bay,2447, vic,19510806,3710651
+rec-7-1036-org, amber, held,24, lampard circuit, emerald garden, golden bay,2447, vic,19510806,3710651
+rec-7-1037-org, connor, beckwith,10, heard street, , mill park,5031, nsw,19081103,2209091
+rec-7-1038-org, danny, campbell,95, totterdell street, moama, shellharbour,2209, vic,19951105,9554924
+rec-7-1039-dup-0, angus, roas,62, gormansto crescent, mlc centre, kiruwah,3350, sa,19250817,2655081
+rec-7-1039-org, angus, rosa,62, gormanston crescent, mlc centre, kirwan,3350, sa,19250817,2655081
+rec-7-104-dup-0, benjaminl, carbone,18, arthella, wattle s treet, orange,3550, vic,19050820,3677127
+rec-7-104-org, benjamin, carbone,18, wattle street, arthella, orange,3550, vic,19050820,3677127
+rec-7-1040-dup-0, matilda, mestrov, , housecicuit, retirement village, taringa,3820, qld,19801119,2536135
+rec-7-1040-dup-1, matilda, mestrv,5, house circuit, retirement village, taringa,3802, qld,19801119,2563135
+rec-7-1040-dup-2, matilda, mestrov,5, house circuit, retiremen tvillage, taringa,3820, ,19801119,2563135
+rec-7-1040-org, matilda, mestrov,5, house circuit, retirement village, taringa,3820, qld,19801119,2563135
+rec-7-1041-dup-0, tyler, frojd, , burramurra avenue, kmart p plaza, san rmeo,3670, sa,19800916,7812219
+rec-7-1041-org, tyler, froud,8, burramurra avenue, kmart p plaza, san remo,3670, sa,19800916,7812219
+rec-7-1042-dup-0, kiandra, ,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-7-1042-dup-1, kiandra, cowle,2, gatliff place, rustenubr g sth, girgarre,3995, qld,19801125,3328205
+rec-7-1042-org, kiandra, cowle,2, gatliff place, rustenburg sth, girgarre,3995, qld,19801125,3328205
+rec-7-1043-org, giorgia, frahn,62, handasyde street, ramano estate locn 1, tallebudgera,4506, vic,19670206,9724789
+rec-7-1044-dup-0, nicole, shadbolt,46, schlich s treet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-dup-1, nicole, carbone,46, schlich nstreet, simpson army barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-dup-2, nicole, carbone,46, schlich street, simpson arm ybarracks, toowong,3000, wa,19030926,8190756
+rec-7-1044-dup-3, nicole, carbone,46, schlich street, simpsonary barracks, toowoomba,3000, wa,19030926,8190756
+rec-7-1044-org, nicole, carbone,46, schlich street, simpson army barracks, toowoomba,3000, wa,19030926,8190756

--- a/spark/core/pom.xml
+++ b/spark/core/pom.xml
@@ -49,12 +49,72 @@
 			<artifactId>junit-jupiter-params</artifactId>
 			<version>5.8.1</version>
 			<scope>test</scope>
-		</dependency>	
-</dependencies>
-<build>
-		
-	
-			<plugins>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<profiles>
+		<profile>
+			<id>benchmark</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<id>run-benchmark</id>
+								<phase>integration-test</phase>
+								<goals><goal>exec</goal></goals>
+								<configuration>
+									<executable>java</executable>
+									<classpathScope>test</classpathScope>
+									<arguments>
+										<argument>-classpath</argument>
+										<classpath/>
+										<argument>org.openjdk.jmh.Main</argument>
+										<argument>BlockingTreeBenchmark</argument>
+										<argument>-rf</argument>
+										<argument>json</argument>
+										<argument>-rff</argument>
+										<argument>${project.build.directory}/benchmark-results.json</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	<build>
+
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.openjdk.jmh</groupId>
+							<artifactId>jmh-generator-annprocess</artifactId>
+							<version>1.37</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/spark/core/src/main/java/zingg/spark/core/block/SparkBlock.java
+++ b/spark/core/src/main/java/zingg/spark/core/block/SparkBlock.java
@@ -9,6 +9,7 @@ import zingg.common.client.ZFrame;
 import zingg.common.client.util.ListMap;
 import zingg.common.core.block.Block;
 import zingg.common.core.block.FieldDefinitionStrategy;
+import zingg.common.core.block.HashUtility;
 import zingg.common.core.feature.FeatureFactory;
 import zingg.common.core.hash.HashFunction;
 import zingg.spark.core.feature.SparkFeatureFactory;
@@ -25,9 +26,15 @@ public class SparkBlock extends Block<Dataset<Row>, Row, Column, DataType> {
 
     public SparkBlock(ZFrame<Dataset<Row>, Row, Column> training, ZFrame<Dataset<Row>, Row, Column> dupes,
                       ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap, long maxSize, FieldDefinitionStrategy<Row> fieldDefinitionStrategy) {
-		super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy);
-	}
-    
+        super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy);
+    }
+
+    public SparkBlock(ZFrame<Dataset<Row>, Row, Column> training, ZFrame<Dataset<Row>, Row, Column> dupes,
+                      ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> functionsMap, long maxSize,
+                      FieldDefinitionStrategy<Row> fieldDefinitionStrategy, HashUtility hashUtility) {
+        super(training, dupes, functionsMap, maxSize, fieldDefinitionStrategy, hashUtility);
+    }
+
     @Override
     public FeatureFactory<DataType> getFeatureFactory() {
         return new SparkFeatureFactory();

--- a/spark/core/src/main/java/zingg/spark/core/hash/SparkHashFunction.java
+++ b/spark/core/src/main/java/zingg/spark/core/hash/SparkHashFunction.java
@@ -57,6 +57,12 @@ public abstract class SparkHashFunction<T1, R> extends HashFunction<Dataset<Row>
         return call((T1)getAs(r, column));
    }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object applyToValue(Object value) {
+        return call((T1) value);
+    }
+
 
     @Override
     public Object apply(Dataset<Row> df, Row r, String column) {

--- a/spark/core/src/test/java/zingg/spark/core/block/BlockingTreeBenchmark.java
+++ b/spark/core/src/test/java/zingg/spark/core/block/BlockingTreeBenchmark.java
@@ -1,0 +1,211 @@
+package zingg.spark.core.block;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import zingg.common.client.FieldDefinition;
+import zingg.common.client.MatchTypes;
+import zingg.common.client.ZinggClientException;
+import zingg.common.client.ZFrame;
+import zingg.common.client.arguments.ArgumentServiceImpl;
+import zingg.common.client.arguments.model.Arguments;
+import zingg.common.client.arguments.model.IArguments;
+import zingg.common.client.util.IWithSession;
+import zingg.common.client.util.ListMap;
+import zingg.common.client.util.WithSession;
+import zingg.common.core.block.Block;
+import zingg.common.core.block.Canopy;
+import zingg.common.core.block.DefaultFieldDefinitionStrategy;
+import zingg.common.core.block.GetBestNode;
+import zingg.common.core.block.HashUtility;
+import zingg.common.core.block.Tree;
+import zingg.common.core.block.data.DataUtility;
+import zingg.common.core.block.model.Customer;
+import zingg.common.core.block.model.CustomerDupe;
+import zingg.common.core.hash.HashFunction;
+import zingg.common.core.util.CsvReader;
+import zingg.common.core.util.Heuristics;
+import zingg.spark.client.SparkClient;
+import zingg.spark.client.util.SparkDFObjectUtil;
+import zingg.spark.core.util.SparkHashUtil;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark comparing the original getBestNode algorithm against the
+ * optimized one (precomputed field values + early-exit + deferred buildDupeRemaining).
+ * Both benchmarks use HashUtility.CACHED so the only variable is the algorithm.
+ *
+ * Run via Maven:
+ *   mvn test-compile exec:exec -Pbenchmark -pl spark/core
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 2, batchSize = 1)
+@Measurement(iterations = 5, batchSize = 1)
+public class BlockingTreeBenchmark {
+
+    private static final String DATA_DIR = "testFebrl";
+    private static final String LARGE_CSV = DATA_DIR + "/test_large.csv";
+    private static final String LARGE_CONFIG = DATA_DIR + "/config_large.json";
+
+    private ZFrame<Dataset<Row>, Row, Column> sample;
+    private ZFrame<Dataset<Row>, Row, Column> positives;
+    private ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions;
+    private long blockSize;
+    private List<FieldDefinition> fieldDefinitions;
+
+    // Pre-collected lists so each invocation creates a fresh Canopy without
+    // triggering a Spark action (collectAsList is done once in setup).
+    private List<Row> trainingList;
+    private List<Row> positivesList;
+
+    private SparkSession spark;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception, ZinggClientException {
+        spark = SparkSession.builder()
+                .master("local[*]")
+                .appName("ZinggBlockingTreeBenchmark")
+                .config("spark.driver.bindAddress", "127.0.0.1")
+                .config("spark.driver.host", "127.0.0.1")
+                .getOrCreate();
+
+        new SparkClient().checkAndSetCheckpoint(spark);
+
+        IWithSession<SparkSession> withSession = new WithSession<>();
+        withSession.setSession(spark);
+        SparkDFObjectUtil dfObjectUtil = new SparkDFObjectUtil(withSession);
+
+        DataUtility dataUtility = new DataUtility(new CsvReader());
+        List<Customer> customers = dataUtility.getCustomers(LARGE_CSV);
+        List<CustomerDupe> customerDupes = dataUtility.getCustomerDupes(LARGE_CSV, false);
+
+        ZFrame<Dataset<Row>, Row, Column> zFrameTest =
+                dfObjectUtil.getDFFromObjectList(customers, Customer.class);
+        ZFrame<Dataset<Row>, Row, Column> zFramePositives =
+                dfObjectUtil.getDFFromObjectList(customerDupes, CustomerDupe.class);
+
+        InputStream configStream = Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream(LARGE_CONFIG),
+                "Config resource not found: " + LARGE_CONFIG
+        );
+        Path tempConfig = Files.createTempFile("zingg-config-", ".json");
+        tempConfig.toFile().deleteOnExit();
+        Files.copy(configStream, tempConfig, StandardCopyOption.REPLACE_EXISTING);
+        IArguments args = new ArgumentServiceImpl<>(Arguments.class).loadArguments(tempConfig.toString());
+
+        sample = zFrameTest.sample(false, 1.0);
+        long totalCount = sample.count();
+        blockSize = Heuristics.getMaxBlockSize(totalCount, args.getBlockSize());
+        positives = zFramePositives.coalesce(1);
+
+        hashFunctions = new SparkHashUtil(spark).getHashFunctionList();
+        fieldDefinitions = getActiveFieldDefinitions(args);
+
+        trainingList = sample.collectAsList();
+        positivesList = positives.collectAsList();
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        if (spark != null) {
+            spark.stop();
+            spark = null;
+        }
+    }
+
+    /** Precomputed field values + early exit + deferred buildDupeRemaining. */
+    @Benchmark
+    public Tree<Canopy<Row>> preComputedFieldValuesEarlyExitAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    /** Precomputed values passed to buildDupeRemaining, avoiding re-extraction on the winner. */
+    @Benchmark
+    public Tree<Canopy<Row>> precomputedWithBuildDupeAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        block.setGetBestNodeStrategy(new GetBestNode<Dataset<Row>, Row, Column, DataType>() {
+            @Override
+            public Canopy<Row> getBestNode(Block<Dataset<Row>, Row, Column, DataType> b,
+                    Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                    List<FieldDefinition> fields) throws Exception {
+                return precomputedBuildDupeRemaining(b, tree, parent, node, fields);
+            }
+        });
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    /** Probe-reuse: one shared probe Canopy per getBestNode call; real Canopy only on new best. */
+    @Benchmark
+    public Tree<Canopy<Row>> probeReuseAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        block.setGetBestNodeStrategy(new GetBestNode<Dataset<Row>, Row, Column, DataType>() {
+            @Override
+            public Canopy<Row> getBestNode(Block<Dataset<Row>, Row, Column, DataType> b,
+                    Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                    List<FieldDefinition> fields) throws Exception {
+                return probeReuse(b, tree, parent, node, fields);
+            }
+        });
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    /** Original getBestNode: calls estimateElimCount() per candidate, builds dupeRemaining for all. */
+    @Benchmark
+    public Tree<Canopy<Row>> originalAlgoTree() throws Exception, ZinggClientException {
+        Canopy<Row> root = new Canopy<>(new ArrayList<>(trainingList), new ArrayList<>(positivesList));
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<>(), HashUtility.CACHED);
+        block.setGetBestNodeStrategy(new GetBestNode<Dataset<Row>, Row, Column, DataType>() {
+            @Override
+            public Canopy<Row> getBestNode(Block<Dataset<Row>, Row, Column, DataType> b,
+                    Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                    List<FieldDefinition> fields) throws Exception {
+                return original(b, tree, parent, node, fields);
+            }
+        });
+        return block.getBlockingTree(null, null, root, fieldDefinitions);
+    }
+
+    private List<FieldDefinition> getActiveFieldDefinitions(IArguments args) {
+        List<FieldDefinition> active = new ArrayList<>();
+        for (FieldDefinition def : args.getFieldDefinition()) {
+            if (!(def.getMatchType() == null || def.getMatchType().contains(MatchTypes.DONT_USE))) {
+                active.add(def);
+            }
+        }
+        return active;
+    }
+
+}

--- a/spark/core/src/test/java/zingg/spark/core/block/TestSparkBlockingTreeUtil.java
+++ b/spark/core/src/test/java/zingg/spark/core/block/TestSparkBlockingTreeUtil.java
@@ -6,14 +6,21 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataType;
 import org.junit.jupiter.api.extension.ExtendWith;
+import zingg.common.client.FieldDefinition;
 import zingg.common.client.ZFrame;
 import zingg.common.client.util.DFObjectUtil;
 import zingg.common.client.util.IWithSession;
 import zingg.common.client.util.ListMap;
 import zingg.common.client.util.WithSession;
 import zingg.common.core.block.Block;
+import zingg.common.core.block.Canopy;
 import zingg.common.core.block.DefaultFieldDefinitionStrategy;
+import zingg.common.core.block.GetBestNode;
+import zingg.common.core.block.HashUtility;
 import zingg.common.core.block.TestBlockingTreeUtil;
+import zingg.common.core.block.Tree;
+
+import java.util.List;
 import zingg.common.core.hash.HashFunction;
 import zingg.common.core.util.BlockingTreeUtil;
 import zingg.common.core.util.HashUtil;
@@ -56,5 +63,25 @@ public class TestSparkBlockingTreeUtil extends TestBlockingTreeUtil<SparkSession
     @Override
     protected Block<Dataset<Row>, Row, Column, DataType> getBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize) {
         return new SparkBlock(sample, positives, hashFunctions, blockSize, new DefaultFieldDefinitionStrategy<Row>());
+    }
+
+    @Override
+    protected Block<Dataset<Row>, Row, Column, DataType> getBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize, HashUtility hashUtility) {
+        return new SparkBlock(sample, positives, hashFunctions, blockSize, new DefaultFieldDefinitionStrategy<Row>(), hashUtility);
+    }
+
+    @Override
+    protected Block<Dataset<Row>, Row, Column, DataType> getOriginalAlgoBlock(ZFrame<Dataset<Row>, Row, Column> sample, ZFrame<Dataset<Row>, Row, Column> positives, ListMap<DataType, HashFunction<Dataset<Row>, Row, Column, DataType>> hashFunctions, long blockSize) {
+        SparkBlock block = new SparkBlock(sample, positives, hashFunctions, blockSize,
+                new DefaultFieldDefinitionStrategy<Row>(), HashUtility.CACHED);
+        block.setGetBestNodeStrategy(new GetBestNode<Dataset<Row>, Row, Column, DataType>() {
+            @Override
+            public Canopy<Row> getBestNode(Block<Dataset<Row>, Row, Column, DataType> b,
+                    Tree<Canopy<Row>> tree, Canopy<Row> parent, Canopy<Row> node,
+                    List<FieldDefinition> fields) throws Exception {
+                return original(b, tree, parent, node, fields);
+            }
+        });
+        return block;
     }
 }

--- a/spark/core/src/test/resources/testFebrl/config_large.json
+++ b/spark/core/src/test/resources/testFebrl/config_large.json
@@ -1,0 +1,95 @@
+{
+	"fieldDefinition":[
+		{
+			"fieldName" : "id",
+			"matchType" : "dont_use",
+			"fields" : "fname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "fname",
+			"matchType" : "fuzzy",
+			"fields" : "fname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "lname",
+			"matchType" : "fuzzy",
+			"fields" : "lname",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "stNo",
+			"matchType": "exact",
+			"fields" : "stNo",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "add1",
+			"matchType": "fuzzy",
+			"fields" : "add1",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "add2",
+			"matchType": "fuzzy",
+			"fields" : "add2",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "city",
+			"matchType": "fuzzy",
+			"fields" : "city",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "areacode",
+			"matchType": "exact",
+			"fields" : "areacode",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "state",
+			"matchType": "exact",
+			"fields" : "state",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "dob",
+			"matchType": "exact",
+			"fields" : "dob",
+			"dataType": "string"
+		},
+		{
+			"fieldName" : "ssn",
+			"matchType": "exact",
+			"fields" : "ssn",
+			"dataType": "string"
+		}
+		],
+		"output" : [{
+			"name":"output",
+			"format":"csv",
+			"props": {
+				"path": "/tmp/testFebrl/zinggOutput",
+				"delimiter": ",",
+				"header":true
+			}
+		}],
+		"data" : [{
+			"name":"test",
+			"format":"csv",
+			"props": {
+				"path": "./testFebrl/test_large.csv",
+				"delimiter": ",",
+				"header":false
+			},
+			"schema": "id string, fname string, lname string, stNo string, add1 string, add2 string, city string, state string, areacode string, dob string, ssn  string"
+			}
+		],
+		"labelDataSampleSize" : 0.5,
+		"numPartitions":4,
+		"modelId": 100,
+		"zinggDir": "./testFebrl/models"
+
+}


### PR DESCRIPTION
Command to run benchmarks: mvn integration-test -Pbenchmark -pl spark/core -am -DskipTests
Output file path: zingg/spark/core/target/benchmark-results.json

Optimizations that are included -

1. Reuse a probe Canopy instead of allocating per candidate
getNodeFromCurrent runs for every (field × function) candidate — with 10 fields × N functions that's potentially 50+ new Canopy + copyTo calls per getBestNode invocation, all immediately discarded. Only the winner needs a real object.
Fix: allocate one probe Canopy at the start of getBestNode, set function and context on it per iteration (both are just field assignments from copyTo), then countEliminationsWithValues and estimateCanopies run on it. Only when a new best is found, materialize a real Canopy with getNodeFromCurrent. This cuts N allocations per call down to 1.

2. Pass precomputed values into buildDupeRemaining
buildDupeRemaining calls function.apply(r, context.fieldName) per row — full row field extraction — even though getBestNode already has preVals1/preVals2 for that exact field. The problem is those arrays are local to the field loop and buildDupeRemaining is called after the loop ends, when the winning field's preVals are out of scope.
Fix: when a new best is found inside the loop, snapshot bestPreVals1 and bestPreVals2 alongside it. Pass them to buildDupeRemaining so it can call function.applyToValue(bestPreVals1[i]) instead of function.apply(r, fieldName) — same savings as countEliminationsWithValues already gets.

3. Precompute field values + early exit in estimateElimCount
estimateElimCount calls function.apply(r, context.fieldName) and function.apply(r, COL_PREFIX + context.fieldName) for every row in dupeN, for every candidate — with 10 fields × N functions × dupeN rows, the same field value is extracted from the Row repeatedly across functions in the same field. Additionally, it builds dupeRemaining for every evaluated candidate, including all the losers that are immediately discarded.

Fix: extract raw field values once per field using getAs before the function loop, storing them in preVals1[] and preVals2[]. For each function, call countEliminationsWithValues(preVals1, preVals2, least) which uses function.applyToValue(preVals[i]) — just the hash transformation on an already-extracted value, not a full Row field lookup. Add early exit: once elimCount >= least (current best), stop counting rows immediately — this candidate cannot win. Defer buildDupeRemaining to after all candidates are evaluated, calling it once only for the winner.


Combined impact: (1) + (2) together eliminate the biggest source of garbage in the hot loop.
All three are single-threaded improvements — they'd stack on top of any parallelization you add later.