### PR TITLE
Remove stale unused name field from Matcher and Linker (#682)

### DIFF
--- a/common/core/src/main/java/zingg/common/core/executor/Linker.java
+++ b/common/core/src/main/java/zingg/common/core/executor/Linker.java
@@ -16,7 +16,6 @@ import zingg.common.core.pairs.SelfPairBuilderSourceSensitive;
 public abstract class Linker<S,D,R,C,T> extends Matcher<S,D,R,C,T> {
 
 	private static final long serialVersionUID = 1L;
-	protected static String name = "zingg.Linker";
 	public static final Log LOG = LogFactory.getLog(Linker.class);
 
 	public Linker() {

--- a/common/core/src/main/java/zingg/common/core/executor/Matcher.java
+++ b/common/core/src/main/java/zingg/common/core/executor/Matcher.java
@@ -31,8 +31,7 @@ import zingg.common.core.util.Metric;
 public abstract class Matcher<S,D,R,C,T> extends ZinggBase<S,D,R,C,T> implements IPreprocessors<S,D,R,C,T> {
 
 	private static final long serialVersionUID = 1L;
-	protected static String name = "zingg.Matcher";
-	public static final Log LOG = LogFactory.getLog(Matcher.class);   
+	public static final Log LOG = LogFactory.getLog(Matcher.class);
 	protected IMatchOutputBuilder<S,D,R,C> matchOutputBuilder; 
 	ZFrame<D, R, C> output = null;
 	boolean toWrite = true;


### PR DESCRIPTION
Fixes #682

### Problem
The abstract `Matcher` and `Linker` classes in `zingg.common.core.executor` carry a leftover field:

```java
protected static String name = "zingg.Matcher";   // Matcher
protected static String name = "zingg.Linker";     // Linker
```

The `"zingg.*"` value dates back to the original single-package layout, when these were concrete classes living directly under package `zingg`. After the multi-module refactor they became abstract bases under `zingg.common.core.executor`, but the string was never updated — so it no longer reflects the package structure, which is exactly what #682 reports.

### Why remove instead of rename
The `name` field is used only as a reflection key by the phase factory:

```java
// SparkZFactory
zinggers.put(ZinggOptions.MATCH, SparkMatcher.name);
zinggers.put(ZinggOptions.LINK,  SparkLinker.name);
...
return (IZingg) Class.forName(zinggers.get(z)).newInstance();
```

The factory references the **concrete** engine classes' own `name` (`SparkMatcher.name`, `SparkLinker.name`, …), which are correct. The abstract base field is:
- never read anywhere (verified by searching the repo for the literal strings and for `Matcher.name` / `Linker.name` reads), and
- unusable via that path anyway — `newInstance()` cannot instantiate an abstract class.

So the base-class field is dead, misleading code. Removing it resolves the issue with no behavioral change.

### Scope
This PR intentionally covers only `Matcher` and `Linker`. The same stale pattern exists on sibling base classes (`TrainMatcher`, `Recommender`, `FindAndLabeller`, `Trainer`, `Documenter`) and can be cleaned up in a follow-up.

### Verification
- `mvn -pl common/core -am compile` → BUILD SUCCESS.