### PR TITLE
Ignore provided-scope (Spark) dependencies in Dependabot (#1289)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,7 @@
-# Dependabot configuration for Zingg.
-# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-#
-# NOTE (issue #1289): Zingg runs *on top of* a Spark cluster (Databricks, EMR,
-# spark-submit classpath). Spark, Scala, and the Jackson libs Spark ships are
-# declared as `provided` scope in the poms — they are compiled against but NOT
-# packaged into the Zingg jar. The runtime environment supplies (and patches)
-# them. Zingg cannot choose their runtime version, so Dependabot PRs/alerts on
-# these are noise. We therefore `ignore` them below.
-# GitHub classifies Maven `provided` scope as "runtime" (not "development"), so
-# there is no built-in scope filter for this yet (dependabot-core#7973) — the
-# ignore list is the config-level lever, and pom <exclusions> remain the real
-# fix for transitive artifacts we must strip from the shipped graph.
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,30 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot configuration for Zingg.
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# NOTE (issue #1289): Zingg runs *on top of* a Spark cluster (Databricks, EMR,
+# spark-submit classpath). Spark, Scala, and the Jackson libs Spark ships are
+# declared as `provided` scope in the poms — they are compiled against but NOT
+# packaged into the Zingg jar. The runtime environment supplies (and patches)
+# them. Zingg cannot choose their runtime version, so Dependabot PRs/alerts on
+# these are noise. We therefore `ignore` them below.
+# GitHub classifies Maven `provided` scope as "runtime" (not "development"), so
+# there is no built-in scope filter for this yet (dependabot-core#7973) — the
+# ignore list is the config-level lever, and pom <exclusions> remain the real
+# fix for transitive artifacts we must strip from the shipped graph.
 
 version: 2
 updates:
-  - package-ecosystem: "*" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "maven"
+    directories:
+      - "/**" # cover the root + all Maven submodules (common/*, spark/*, ...)
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      # --- provided scope: supplied by the Spark runtime, not shipped by Zingg ---
+      - dependency-name: "org.apache.spark:*"
+      - dependency-name: "org.scala-lang:*"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-core"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      # NOTE: jackson-annotations is `compile` scope (shipped in the jar) — do
+      # NOT ignore it; its alerts are real and actionable.


### PR DESCRIPTION
Fixes #1289.

Zingg runs on top of a Spark cluster, so Spark, Scala, and the Jackson libraries Spark ships are declared `provided` in the poms — we compile against them but don't package them into the Zingg jar. The runtime (Databricks/EMR/etc.) supplies and patches them, and we can't control which versions run, so Dependabot alerts on these are just noise. Until now we'd been silencing them one at a time with manual pom edits.

This scopes `.github/dependabot.yml` to Maven — the old `*` value was actually invalid, so Dependabot had been rejecting the whole file — and ignores the provided-scope groups: `org.apache.spark:*`, `org.scala-lang:*`, `jackson-core`, and `jackson-databind`. `jackson-annotations` is deliberately left in: it's `compile` scope and actually shipped, so its alerts are real.

Tested on a fork — the config went from rejected to valid, and Dependabot now runs Maven jobs with the new settings applied.

One caveat: this covers the directly-declared `provided` deps. Transitive libraries pulled in through Spark (netty, lz4, guava, …) surface under their own names, so they stay covered by the pom `<exclusions>` rather than this ignore list.