### PR TITLE
Fix labeler truncating field values in vertical display

### DIFF
--- a/common/client/src/main/java/zingg/common/client/ZFrame.java
+++ b/common/client/src/main/java/zingg/common/client/ZFrame.java
@@ -120,6 +120,7 @@ public interface ZFrame<D, R, C> {
     public C or(C col1, C col2);
 
     public void show(int num);
+    public void show(int num, boolean truncate);
     public void show();
 
     public String showSchema();

--- a/common/client/src/main/java/zingg/common/client/util/vertical/VerticalDisplayUtility.java
+++ b/common/client/src/main/java/zingg/common/client/util/vertical/VerticalDisplayUtility.java
@@ -18,7 +18,7 @@ public class VerticalDisplayUtility<S, D, R, C> {
 
     public void showVertical(ZFrame<D, R, C> zFrame) throws ZinggClientException {
         ZFrame<D, R, C> verticalZFrame = convertVertical(zFrame);
-        verticalZFrame.show(MAX_COLUMNS);
+        verticalZFrame.show(MAX_COLUMNS, false);
     }
 
     public ZFrame<D, R, C> convertVertical(ZFrame<D, R, C> zFrame) throws ZinggClientException {

--- a/spark/client/src/main/java/zingg/spark/client/SparkFrame.java
+++ b/spark/client/src/main/java/zingg/spark/client/SparkFrame.java
@@ -312,6 +312,10 @@ public class SparkFrame implements ZFrame<Dataset<Row>, Row, Column> {
         df.show(num);
     }
 
+    public void show(int num, boolean truncate) {
+        df.show(num, truncate);
+    }
+
     public void show() {
         df.show();
     }


### PR DESCRIPTION
The labeler rendered pairs via ZFrame.show(int), which lets Spark default to truncate=true, capping cell values at 20 characters (e.g. emails shown as john_smith@cas...). Add a show(int, boolean) overload to ZFrame and SparkFrame, and have VerticalDisplayUtility call show(MAX_COLUMNS, false) so full values are displayed.