### PR TITLE
docs: remove leaked internal review notes from published pages

### DIFF
--- a/docs/accuracy/stopWordsRemoval.md
+++ b/docs/accuracy/stopWordsRemoval.md
@@ -29,8 +29,7 @@ Once you have verified the above stop words, you can configure them in the JSON 
 
 In case of stopwords being set up manually by the user, the list of stopwords may consider multiple columns and Zingg used only the first column by default.
 
-
-For recommending stopwords in **Zingg Enterprise Snowflake**, 
+For recommending stopwords in **Zingg Enterprise Snowflake**,
 
 `./scripts/zingg.sh --phase recommend --conf <conf.json> --properties-file <path to Snowflake properties file> --column <name of column to generate stopword recommendations>`
 

--- a/docs/connect-your-data/connect-cloud-storage.md
+++ b/docs/connect-your-data/connect-cloud-storage.md
@@ -156,10 +156,6 @@ Setting `zinggDir` to an S3 path stores all Zingg model files and training data 
 {% endhint %}
 {% endtab %}
 
-{% tab title="Azure Blob" %}
-_**CHECK WITH SONAL - - NEED TEAMS HELP TO CHECK WHAT EXACTLY TO BE ADDED HERE**_
-{% endtab %}
-
 {% tab title="GCS" %}
 On Google Cloud Storage, data lives in GCS buckets accessed via the `gs://` path format. Use `gs://<bucket-name>/<path-to-file>` to connect Zingg to your bucket. All formats — CSV, Parquet, JSON, Avro, Delta — are available in both Community and Enterprise.
 

--- a/docs/connect-your-data/connect-file-formats.md
+++ b/docs/connect-your-data/connect-file-formats.md
@@ -232,8 +232,6 @@ args.setData(tsvPipe)
 
 **XLSX**
 
-_**CHECK WITH SONAL - XLSX is listed as supported on zingg.ai but the connector format string and Python class are not confirmed on any live docs page. Please confirm the XLSX config and whether it is all editions or ENT only.**_
-
 {% hint style="success" icon="right-long" %}
 For files on cloud platforms:
 

--- a/docs/dataSourcesAndSinks/mongodb.md
+++ b/docs/dataSourcesAndSinks/mongodb.md
@@ -5,16 +5,15 @@ parent: Data Sources and Sinks
 nav_order: 5
 ---
 
-
 ## MongoDB
 
 ```json
 "data" : [{
-		"name":"mongodb", 
-		"format":"mongo", 
+		"name":"mongodb",
+		"format":"mongo",
 		"props": {
-			"uri": "mongodb://127.0.0.1/people.contacts"		
-			}	
+			"uri": "mongodb://127.0.0.1/people.contacts"
+			}
 		}]
 
 ```

--- a/docs/dataSourcesAndSinks/parquet.md
+++ b/docs/dataSourcesAndSinks/parquet.md
@@ -5,14 +5,13 @@ parent: Data Sources and Sinks
 nav_order: 5
 ---
 
-
 ## Parquet files
 ```json
 "data" : [{
-		"name":"parquetFiles", 
-		"format":"parquet", 
+		"name":"parquetFiles",
+		"format":"parquet",
 		"props": {
-			"path": "/home/zingg"		
-			}	
+			"path": "/home/zingg"
+			}
 		}]
 ```

--- a/docs/explainoutput/README.md
+++ b/docs/explainoutput/README.md
@@ -26,6 +26,4 @@ The `explainOutput` phase currently focuses on **probabilistic matches** between
 
 This focused approach allows the explain phase to efficiently highlight the machine learning model's decision-making process for probabilistic matches, which typically require the most scrutiny and validation.
 
-
-
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to https://www.zingg.ai/product/zingg-entity-resolution-compare-versions for individual tier features.

--- a/docs/explainoutput/stats/README.md
+++ b/docs/explainoutput/stats/README.md
@@ -16,8 +16,6 @@ If you’ve ever asked “how deterministic rules are performing?” or “did m
 * Identify highly central records (connectors) and outliers
 * Track how clusters change across runs (growth, splits, merges, reassignments)
 
-
-
 If the number of clusters changes disproportionately to the number of records updated or added, an alert could be triggered.&#x20;
 
 ***
@@ -29,7 +27,5 @@ Zingg writes statistics to the stats directory whenever you run phases like matc
 * SUMMARY: High-level run summary
 * CLUSTER: One row per cluster with cluster level matching metrics
 * RECORD: One row per record with its matching metrics within its cluster
-
-
 
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to [Zingg Entity Resolution Compare Versions](https://www.zingg.ai/product/zingg-entity-resolution-compare-versions) for individual tier features.

--- a/docs/interpreting-results/explain-a-specific-cluster.md
+++ b/docs/interpreting-results/explain-a-specific-cluster.md
@@ -99,7 +99,4 @@ If you prefer the CLI, create an `explainConfig.json` and run with the `--zinggi
 ```
 {% endtab %}
 
-{% tab title="Enterprise Snowflake" %}
-**CONTENT FOR THIS SECTION TO BE PROVIDED BY SONAL LATER**
-{% endtab %}
 {% endtabs %}

--- a/docs/interpreting-results/interpret-output-scores.md
+++ b/docs/interpreting-results/interpret-output-scores.md
@@ -108,9 +108,6 @@ output.groupBy("ZINGG_ID") \
 ```
 {% endtab %}
 
-{% tab title="Enterprise Snowflake" %}
-**CONTENT FOR THIS SECTION TO BE GIVEN BY SONAL LATER**
-{% endtab %}
 {% endtabs %}
 
 {% hint style="success" icon="right-long" %}

--- a/docs/interpreting-results/output-statistics.md
+++ b/docs/interpreting-results/output-statistics.md
@@ -60,9 +60,6 @@ The `$ZINGG_DYNAMIC_STAT_NAME` placeholder is automatically substituted with the
 {% endhint %}
 {% endtab %}
 
-{% tab title="Enterprise Snowflake" %}
-**CONTENT FOR THIS SECTION TO BE PROVIDED BY SONAL LATER**
-{% endtab %}
 {% endtabs %}
 
 ### Three statistics levels

--- a/docs/passthru.md
+++ b/docs/passthru.md
@@ -22,6 +22,4 @@ Note: Zingg internally applies the **negation** of the `passthroughExpr` to filt
      "passthroughExpr": "is_deceased = true AND is_deceased is NOT NULL"
 ```
 
-
-
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to https://www.zingg.ai/product/zingg-entity-resolution-compare-versions for individual tier features.

--- a/docs/platform-guides/platform-guide-for-aws-emr.md
+++ b/docs/platform-guides/platform-guide-for-aws-emr.md
@@ -9,8 +9,6 @@ description: >-
 AWS EMR provides managed Spark on AWS infrastructure. Zingg runs on EMR using the standard Python API for Community and EZingg for Enterprise. S3 is used for data storage and\
 model persistence using the `s3a://` path format.
 
-**CONTENT TO BE GIVEN BY NILANJAN/SIDDIK**
-
 {% tabs %}
 {% tab title="Community" %}
 

--- a/docs/platform-guides/platform-guide-for-aws-glue.md
+++ b/docs/platform-guides/platform-guide-for-aws-glue.md
@@ -39,8 +39,6 @@ Create an S3 bucket (for example `zingg-production-storage`) and upload all six 
 
 Download all JARs from `github.com/zinggAI/zingg/releases`. Also upload your data file to the bucket root.
 
-_**IMAGE TO BE ADDED — S3 bucket view showing the\*\*\*\*****&#x20;****`/jars/`****&#x20;****\*\*\*\*folder with all six Zingg JAR files listed. Tanwi to check with team for the screenshot.**_
-
 #### **Step 2: Create an IAM role for Glue**
 
 AWS Glue Interactive Sessions require a dedicated IAM Role that allows the notebook to read and write S3, run Glue jobs, and pass the role to the Glue service.
@@ -99,16 +97,12 @@ Create an inline policy named `ZinggSessionPermissions` with the following JSON.
 }
 ```
 
-_**IMAGE TO BE ADDED — IAM Role creation screen in the AWS Console showing the role name, attached managed policies, and the inline policy editor. Tanwi to check with team for the screenshot.**_
-
 #### **Step 3: Create a Glue notebook and attach the IAM role**
 
 1. Navigate to **AWS Glue Studio → Notebooks**.
 2. Choose **Jupyter Notebook** → **Interactive Session**.
 3. Select the IAM role created in Step 2 (`zingg-glue-role`) from the dropdown.
 4. Open the notebook. Confirm the kernel in the top right shows **Glue PySpark**.
-
-_**IMAGE TO BE ADDED — AWS Glue Studio Notebooks screen showing the IAM role dropdown with the\*\*\*\*****&#x20;****`zingg-glue-role`****&#x20;****\*\*\*\*selected. Tanwi to check with team for the screenshot.**_
 
 ### Notebook 01: Set up Zingg
 
@@ -295,8 +289,6 @@ print(f"Previewing data from {csv_path}:")
 spark_df.show(10)
 ```
 
-_**IMAGE TO BE ADDED - Glue notebook cell showing the\*\*\*\*****&#x20;****`spark_df.show(10)`****&#x20;****\*\*\*\*output table with sample FEBRL records — the same entity appearing multiple times with field variations across rows. Tanwi to check with team for the screenshot.**_
-
 #### **Step 11: Configure input and output pipes**
 
 `CsvPipe` connects Zingg to your S3 data. The schema string must match your dataset column names exactly.
@@ -465,8 +457,6 @@ ready_for_save = True
 print(f"Review sheet exported for {n_pairs} pairs to: {export_path}")
 ```
 
-_**IMAGE TO BE ADDED — S3 console showing the\*\*\*\*****&#x20;****`/review/`****&#x20;****folder with the exported****&#x20;****`pending_labels.csv`****&#x20;****\*\*\*\*part file ready for download. Tanwi to check with team for the screenshot.**_
-
 {% hint style="danger" icon="right-long" %}
 How to label the review sheet:
 
@@ -476,8 +466,6 @@ How to label the review sheet:
 4. Save the file and upload it back to the same S3 path: `s3://your-bucket/review/`
 5. Run Step 16 to feed the labels into Zingg.
 {% endhint %}
-
-_**IMAGE TO BE ADDED — Example of the exported review CSV open in Excel showing two FEBRL records side by side in a vertical layout, with the\*\*\*\*****&#x20;****`>>> DECISION`****&#x20;****row highlighted and a****&#x20;****`1`****&#x20;****entered in the****&#x20;****`Record_B`****&#x20;****\*\*\*\*column. Tanwi to check with team for the screenshot.**_
 
 {% hint style="success" icon="right-long" %}
 Target 30–40 match pairs and 30–40 non-match pairs before training. Repeat Steps 14–16 in a loop until you reach this target. Label until all field types and data variation patterns in your schema are covered. If accuracy needs improvement after the first match run, return to labeling and focus on patterns that are missing or underrepresented.
@@ -648,7 +636,6 @@ print(f"Redundancy Reduced by: "
     f"{((total_records - unique_entities) / total_records) * 100:.2f}%")
 ```
 
-_**IMAGE TO BE ADDED — Glue notebook cell showing\*\*\*\*****&#x20;****`final_results.orderBy("z_cluster").show(10)`****&#x20;****output with resolved records grouped by****&#x20;****`z_cluster`****&#x20;****\*\*\*\*— two rows sharing the same cluster value visible in the output. Tanwi to check with team for the screenshot.**_
 {% endtab %}
 
 {% tab title="Enterprise" %}

--- a/docs/platform-guides/platform-guide-for-azure-databricks.md
+++ b/docs/platform-guides/platform-guide-for-azure-databricks.md
@@ -222,8 +222,6 @@ A widget displays each candidate pair side by side. For each pair, select:
 
 The widget code handles the display and state management. Run the cell to render it.
 
-_**IMAGE TO BE ADDED — Zingg labeling widget in a Databricks notebook showing two candidate records side by side with Match / No Match / Uncertain toggle buttons. Tanwi to check with team for a screenshot from a live notebook run.**_
-
 {% hint style="success" icon="right-long" %}
 Target 30–40 match pairs and 30–40 non-match pairs before training. Repeat Steps 10–12 until you reach this target. Label until all field types and data variation patterns in your schema are covered. If results need improvement after the first match run, return to labeling and focus on patterns that are missing or underrepresented.
 {% endhint %}
@@ -286,8 +284,6 @@ display(df)
 print(df.count())
 ```
 
-_**IMAGE TO BE ADDED — match output table in Databricks showing resolved records with\*\*\*\*****&#x20;****`Z_CLUSTER`****&#x20;****column visible alongside original fields. Ideally highlight two rows sharing the same****&#x20;****`Z_CLUSTER`****&#x20;****\*\*\*\*to show they have been resolved to the same entity. Tanwi to check with team for screenshot from a live notebook run.**_
-
 {% hint style="success" icon="right-long" %}
 Records sharing the same `Z_CLUSTER` value have been resolved to the same real-world entity. `Z_MINSCORE` is the weakest match confidence within the cluster. `Z_MAXSCORE` is the strongest. For full output column definitions → [Interpret Output Scores](../interpreting-results/interpret-output-scores.md).
 {% endhint %}
@@ -305,7 +301,6 @@ DOCS_DIR = zinggDir + "/" + modelId + "/docs/"
 displayHTML(open(DOCS_DIR + "model.html", 'r').read())
 ```
 
-_**IMAGE TO BE ADDED —****&#x20;****`generateDocs`****&#x20;****HTML output rendered inside a Databricks notebook showing labeled pair examples. Tanwi to check with team for screenshot from a live notebook run. Even a small portion of the rendered HTML is sufficient — it tells the reader what to expect before they run it. Place: below the****&#x20;****`displayHTML`****\*\*\*\*\*\*\*\* \*\*\*\*line.**_
 {% endtab %}
 
 {% tab title="Enterprise" %}
@@ -327,8 +322,6 @@ Enterprise requires a Zingg licence and the `zinggEC` and `zinggES` packages. [C
 4. Upload `zingg-enterprise-spark-0.6.0.jar` and `zingg_license.jar` to the Volume.
 5. Open the cluster → **Libraries** → **Install New** → **Volumes** → navigate to: `/Volumes/catalog_name/schema_name/volume_name/zingg-enterprise-spark-0.6.0.jar`
 6. Repeat for `zingg_license.jar`.
-
-_**IMAGE TO BE ADDED — Databricks cluster Libraries tab showing the Enterprise JAR files installed from a Volume path. Tanwi to check with team for screenshot from a live Enterprise cluster setup.**_
 
 #### Step 2: Verify all three packages are installed
 
@@ -530,8 +523,6 @@ stopwordsForStreet = spark.read.csv(
 stopwordsForStreet.show()
 ```
 
-_**IMAGE TO BE ADDED — Databricks notebook showing the stopwords output table with word and frequency columns. Tanwi to check with team for screenshot from a live notebook run. A simple table with 10–15 rows is sufficient that tells the reader what the recommendation output looks like before they run it.**_
-
 #### **Step 15: Apply stopwords to the field definition**
 
 Review the recommendations. You can use them as-is or edit the list — add or remove words that matter for your specific dataset.
@@ -588,8 +579,6 @@ else:
 
 The Enterprise widget shows one pair at a time with Prev and Next navigation. For each pair select `Match`, `No Match`, or `Uncertain`. Labels are saved directly to the `DataFrame` as you click.
 
-_**IMAGE TO BE ADDED — Enterprise labeling widget in a Databricks notebook: two records displayed in a table, Match / No Match / Uncertain toggle buttons, Prev and Next navigation. Tanwi to check with team for screenshot from a live Enterprise notebook run. If the OS and Enterprise widgets look identical, the same screenshot can be reused.**_
-
 {% hint style="info" icon="right-long" %}
 Target 30–40 match pairs and 30–40 non-match pairs before training. Repeat Steps 17–19 until all field types and data patterns are represented. If accuracy needs improvement after the first match run, return here and focus on patterns that are underrepresented.
 {% endhint %}
@@ -628,8 +617,6 @@ data_html = "\n".join(r.value for r in data_doc.collect())
 displayHTML(data_html)
 ```
 
-_**IMAGE TO BE ADDED —****&#x20;****`generateDocs`****\*\*\*\* \*\*\*\*output rendered inside a Databricks notebook showing labeled pair examples in HTML. Tanwi to check with team for screenshot from a live notebook run. Can reuse the OS version if the output looks the same.**_
-
 ### Notebook 05: Train and match
 
 #### **Step 21: Train the model**
@@ -655,8 +642,6 @@ outputDF = spark.read.csv(output_path, header=True)
 display(outputDF)
 print(outputDF.count())
 ```
-
-_**IMAGE TO BE ADDED — Enterprise match output in Databricks showing\*\*\*\*****&#x20;****`ZINGG_ID`****&#x20;****column alongside resolved records. Show two rows with the same****&#x20;****`ZINGG_ID`****&#x20;****\*\*\*\*to illustrate entity resolution. Tanwi to check with team for screenshot from a live notebook run.**_
 
 {% hint style="success" icon="right-long" %}
 **Read more**: Enterprise output includes `ZINGG_ID` — a globally unique, persistent identifier for each resolved entity. Unlike `Z_CLUSTER` in Community, `ZINGG_ID` does not change between runs including incremental runs.
@@ -754,8 +739,6 @@ outputDF = spark.read.csv(explain_output, header=True)
 display(outputDF)
 print(outputDF.count())
 ```
-
-_**IMAGE TO BE ADDED — explain output table in Databricks showing\*\*\*\*****&#x20;****`pk1`****,****&#x20;****`pk2`****\*\*\*\*, and similarity score columns for matched pairs within the cluster. Tanwi to check with team for screenshot from a live notebook run. A small 5–10 row output table is sufficient.**_
 
 {% hint style="success" icon="right-long" %}
 **Read more**: Each row in the output represents a matched record pair within the cluster — `pk1` and `pk2` are the primary keys of the two records, with their similarity score.

--- a/docs/platform-guides/platform-guide-for-gcp-dataproc.md
+++ b/docs/platform-guides/platform-guide-for-gcp-dataproc.md
@@ -32,8 +32,6 @@ Create a GCS bucket and upload the JARs and your dataset. You can do this from t
 3. Set the region to match where your Dataproc cluster will run (for example `us-central1`).
 4. Upload the three JARs and your data file (for example `customers.csv`) to the bucket.
 
-_**IMAGE TO BE ADDED - GCS bucket creation screen in the Google Cloud Console showing bucket name, region selector, and upload interface. Tanwi to check with team for screenshot from a live GCS console.**_
-
 #### gcloud CLI
 
 ```bash
@@ -59,8 +57,6 @@ The cluster must be created with the three JARs injected via `spark.jars`. This 
 5. Scroll to **Properties** and add:
    * **Key:** `spark.jars`
    * **Value:** `gs://YOUR_BUCKET/zingg-0.6.0.jar,gs://YOUR_BUCKET/spark-3.5-bigquery-0.44.1.jar,gs://YOUR_BUCKET/gcs-connector-hadoop3-latest.jar`
-
-_**IMAGE TO BE ADDED — Dataproc cluster creation screen showing the Properties section with\*\*\*\*****&#x20;****`spark.jars`****&#x20;****key and the three JAR paths as the value. Tanwi to check with team for screenshot from a live Dataproc console. This is the most important screenshot on the page — the****&#x20;****`spark.jars`****&#x20;****\*\*\*\*Properties field is not obvious to find and a screenshot here prevents the most common setup error.**_
 
 #### gcloud CLI
 
@@ -92,8 +88,6 @@ Once your cluster status shows **Running**, access the managed JupyterLab enviro
 3. Click the **Web Interfaces** tab.
 4. Under **Component Gateway**, click the **JupyterLab** link.
 5. Create a new notebook and select the **PySpark** kernel.
-
-_**IMAGE TO BE ADDED— Dataproc cluster Web Interfaces tab showing the Component Gateway section with the JupyterLab link highlighted. Tanwi to check with team for screenshot from a live Dataproc cluster.**_
 
 ### Step 4: Set a checkpoint directory and install Zingg
 
@@ -199,8 +193,6 @@ spark_df = spark_df.toDF(*schema_list)
 
 spark_df.limit(10).toPandas().head()
 ```
-
-_**IMAGE TO BE ADDED — Jupyter notebook cell showing the preview output table with sample FEBRL data — the same customer appearing multiple times with field variations across rows. Source: not in the GCP docx (text-only guide). Tanwi to screenshot from a live notebook run. Same principle as the Databricks guide — this image shows readers the exact problem Zingg is solving before they configure anything. Place: below the\*\*\*\*****&#x20;****`spark_df.limit(10).toPandas().head()`****&#x20;****\*\*\*\*line.**_
 
 ### Step 8: Configure input and output pipes
 
@@ -353,8 +345,6 @@ display(widgets.VBox(children=vContainers))
 ready_for_save = True
 ```
 
-_**IMAGE TO BE ADDED — Zingg labeling widget rendered in JupyterLab on Dataproc, showing two candidate records side by side with Match / No Match / Uncertain toggle buttons. Tanwi to check with team for screenshot from a live Dataproc notebook run.**_
-
 {% hint style="success" icon="right-long" %}
 Target 30–40 match pairs and 30–40 non-match pairs before training. Repeat Steps 11–14 in a loop until you reach this target. Label until all field types and data variation patterns in your schema are covered. If accuracy needs improvement after the first match run, return to labeling and focus on patterns that are underrepresented.
 {% endhint %}
@@ -411,8 +401,6 @@ with open(DOCS_DIR + "data.html", 'r') as f:
     display(HTML(f.read()))
 ```
 
-_**IMAGE TO BE ADDED—****&#x20;****`generateDocs`****\*\*\*\* \*\*\*\*HTML output rendered inside JupyterLab on Dataproc showing labeled pair examples. Source: not in the GCP docx. Tanwi to check with team for screenshot from a live notebook run.**_
-
 {% hint style="success" icon="right-long" %}
 `generateDocs` is optional. Skip it if you have 30–40 matches and 30–40 non-matches and are confident in your labeling quality.
 {% endhint %}
@@ -460,8 +448,6 @@ colNames = [
 final_results = outputDF.toDF(*colNames)
 final_results.show(10)
 ```
-
-_**IMAGE TO BE ADDED — match output table in JupyterLab on Dataproc showing resolved records with\*\*\*\*****&#x20;****`z_cluster`****&#x20;****column visible. Highlight two rows sharing the same****&#x20;****`z_cluster`****&#x20;****\*\*\*\*value to show they have been resolved to the same entity.Tanwi to check with team for screenshot from a live notebook run.**_
 
 {% hint style="success" icon="right-long" %}
 * `z_cluster`— unique entity ID assigned by Zingg. All records sharing the same `z_cluster` represent the same real-world entity. Group by `z_cluster` to collapse duplicates into a golden record.

--- a/docs/platform-guides/platform-guide-for-microsoft-fabric.md
+++ b/docs/platform-guides/platform-guide-for-microsoft-fabric.md
@@ -192,8 +192,6 @@ data.columns = schema
 data.head()
 ```
 
-_**IMAGE TO BE ADDED — Fabric notebook cell showing the data preview output table with sample FEBRL records — the same entity appearing multiple times with field variations across rows. Tanwi to check with team for screenshot from a live Fabric notebook run.**_
-
 #### **Step 12: Configure input and output pipes**
 
 `CsvPipe` connects Zingg to your OneLake data. The schema string must match your dataset column names exactly.
@@ -350,8 +348,6 @@ display(widgets.VBox(children=vContainers))
 ready_for_save = True
 ```
 
-_**IMAGE TO BE ADDED — Zingg labeling widget running inside a Fabric notebook showing two candidate records side by side with Match / No Match / Uncertain toggle buttons. Tanwi to check with team for screenshot from a live Fabric notebook run.**_
-
 {% hint style="success" icon="right-long" %}
 Target 30–40 match pairs and 30–40 non-match pairs before training. Repeat Steps 15–18 in a loop until you reach this target. Label until all field types and data variation patterns in your schema are covered. If accuracy needs improvement after the first match run, return to labeling and focus on patterns that are missing or underrepresented.
 {% endhint %}
@@ -414,8 +410,6 @@ displayHTML(open(DOCS_DIR + "model.html", 'r').read())
 displayHTML(open(DOCS_DIR + "data.html", 'r').read())
 ```
 
-_**IMAGE TO BE ADDED —****&#x20;****`generateDocs`****\*\*\*\* \*\*\*\*HTML output rendered inside a Fabric notebook showing labeled pair examples in a table. Tanwi to check with team for screenshot from a live Fabric notebook run.**_
-
 ### Notebook 04: Train and match
 
 This notebook runs `trainMatch` and displays the output. It calls `%run 01-setting_up_zingg` at the top.
@@ -458,7 +452,6 @@ display(outputDF)
 print(outputDF.count())
 ```
 
-_**IMAGE TO BE ADDED— Match output table in a Fabric notebook showing resolved records with\*\*\*\*****&#x20;****`z_cluster`****&#x20;****\*\*\*\*column visible — two rows sharing the same cluster value highlighted to illustrate entity resolution. Tanwi to check with team for screenshot from a live Fabric notebook run.**_
 {% endtab %}
 
 {% tab title="Enterprise" %}

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -4,8 +4,6 @@ nav_order: 11
 
 # Reading Material
 
-
-
 Entity Resolution and The Modern Data Stack:
 
 * [From Rows to People](https://roundup.getdbt.com/p/from-rows-to-people)
@@ -25,4 +23,3 @@ A detailed write-up on entity resolution - the problem, its challenges, and appl
 Understanding Master Data and Master Data Management:
 
 * [Agile Data Mastering](https://towardsdatascience.com/a-guide-to-agile-data-mastering-with-ai-3bf38f103709)
-

--- a/docs/reassignZinggId.md
+++ b/docs/reassignZinggId.md
@@ -164,7 +164,7 @@ This wrapper configuration points to your new configuration and specifies where 
 }
 ```
 
-**Note**: 
+**Note**:
 - This wrapper only points to the new configuration. The original configuration is specified via the `--originalZinggId` command-line parameter.
 - The `name` field in `transformedOutputPath` can be any arbitrary identifier for the output pipe - it's used internally by Zingg to identify this output destination.
 
@@ -384,6 +384,5 @@ Migrating from Databricks to Fabric, or vice versa? When migrating data to new s
 
 ### 5. Platform Upgrades
 Upgrading Spark versions, Snowflake features, or other platform components? Keep your IDs stable through the upgrade process.
-
 
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to https://www.zingg.ai/product/zingg-entity-resolution-compare-versions for individual tier features.

--- a/docs/recipes-and-integration/combine-match-models.md
+++ b/docs/recipes-and-integration/combine-match-models.md
@@ -129,5 +129,3 @@ The combination is defined in a JSON config file with two top-level arrays: `ver
 * `strategy: 'pairs_and_vertices'` - the graph combination strategy. Determines how overlapping entity assignments are resolved.
 
 #### PYTHON API
-
-_**CHECK WITH SONAL \_ TEAM - Python API for combining match models is not documented in the reference PDF. Sonal to confirm before adding.**_

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -15,22 +15,22 @@ In such cases, Zingg can build the entire graph and relate different models toge
 
 ````json
 ```
-{ 
-    "vertices" : 
-    [ 
-        { 
-            "name" : "spouse",  
-            "vertexType" : "zingg_pipe", 
+{
+    "vertices" :
+    [
+        {
+            "name" : "spouse",
+            "vertexType" : "zingg_pipe",
             "data" : [
                 {
-                "name" : "spouse", 
-                "format" : "snowflake", 
+                "name" : "spouse",
+                "format" : "snowflake",
                 "props": {
                         "query": "select a.id as id, a.FNAME, a.LNAME, a.STNO, a.ADD1, a.CITY, a.STATE, a.ZINGG_ID_PERSON, b.id as z_id, b.fname as Z_FNAME,b.lname as Z_LNAME,b.stno as Z_STNO,b.add1 as Z_ADD1, b.city as Z_CITY,b.state as Z_STATE, b.ZINGG_ID_PERSON as Z_ZINGG_ID_PERSON from CUSTOMER_RELATE_PARTIAL a, CUSTOMER_RELATE_PARTIAL b where a.familyId = b.familyId"
                         }
                 }
                 ],
-            "edges" :  
+            "edges" :
             {   "edgeType" : "same_edge",
                 "edges":[
                     {
@@ -46,9 +46,9 @@ In such cases, Zingg can build the entire graph and relate different models toge
                 ]
             }
         },
-        { 
+        {
             "name" : "household",
-            "config" : "$ZINGG_ENTERPRISE_HOME$/zinggEnterprise/configHousehold.json", 
+            "config" : "$ZINGG_ENTERPRISE_HOME$/zinggEnterprise/configHousehold.json",
             "strategy" : {
                 "vDataStrategy" : "unique_edge",
                 "props" : {
@@ -56,8 +56,8 @@ In such cases, Zingg can build the entire graph and relate different models toge
                         "edge" : "zingg_personId,z_zingg_personId"
                     }
             },
-            "vertexType" : "zingg_match", 
-             "edges" :  
+            "vertexType" : "zingg_match",
+             "edges" :
             {   "edgeType" : "same_edge",
                 "edges":[
                     {
@@ -75,15 +75,14 @@ In such cases, Zingg can build the entire graph and relate different models toge
         }
     ],
     "output" : [{
-        "name":"relatedCustomers", 
-        "format":"snowflake", 
+        "name":"relatedCustomers",
+        "format":"snowflake",
         "props": {
             "table": "RELATED_CUSTOMERS_PARTIAL"
             }
     }],
     "strategy":"pairs_and_vertices"
 }
-
 
 ```
 ````

--- a/docs/running-zingg/build-and-save-the-model.md
+++ b/docs/running-zingg/build-and-save-the-model.md
@@ -67,7 +67,6 @@ Available options:
 Enterprise only. Zingg on Snowflake uses Snowpark and does not require a Spark cluster.
 {% endhint %}
 
-
 ### CLI
 
 ```bash

--- a/docs/running-zingg/cluster-approval.md
+++ b/docs/running-zingg/cluster-approval.md
@@ -19,8 +19,6 @@ After Zingg runs the match or incremental phase, some clusters may need human re
 Approved and rejected decisions are stored by Zingg and preserved across subsequent incremental runs. Zingg will not override a human-approved or human-rejected cluster decision\
 in future runs, the human decision always takes precedence.
 
-_**CHECK WITH SONAL—The cluster approval page currently shows "Coming Soon" on the live docs with no technical content. All content above is written from KT notes and the incremental page context. Please review and confirm**_
-
 ### When to use cluster approval
 
 Records are high-stakes, and errors have downstream consequences. For example, a financial compliance system that links counterparties to sanctions lists or a KYC system where a false match could affect a customer's account.

--- a/docs/running-zingg/compare-model-results.md
+++ b/docs/running-zingg/compare-model-results.md
@@ -116,9 +116,6 @@ zinggDiff.initAndExecute()
 ```
 {% endtab %}
 
-{% tab title="Enterprise for Snowflake" %}
-_**Enterprise Snowflake content for this topic to be provided by Sonal**_
-{% endtab %}
 {% endtabs %}
 
 ### Understand why use Diff with use cases

--- a/docs/running-zingg/experience-zingg.md
+++ b/docs/running-zingg/experience-zingg.md
@@ -10,8 +10,6 @@ description: >-
 **Prerequisites:** Docker installed on your machine. Nothing else required.
 {% endhint %}
 
-_**CHECK WITH SONAL - IF WE STILL NEED THIS PAGE AS PER THE NEW GROUPING - AS WE HAVE A DEDICATED PAGE FOR DOCKER - QUICK START. OUR INITIAL IDEA ABOUT KEEPING THIS PAGE IS NOW CHANGED.**_
-
 The fastest way to understand what Zingg does is to see it work. This page uses Docker and\
 a pre-trained model bundled with Zingg to run entity resolution on a sample dataset in three\
 commands. There is no installation, no configuration, and no labeling required.

--- a/docs/running-zingg/install-zingg.md
+++ b/docs/running-zingg/install-zingg.md
@@ -169,18 +169,6 @@ Run Zingg Python code directly in AWS EMR Notebooks using the Python API. Instal
 ```
 {% endtab %}
 
-{% tab title="AWS Glue" %}
-**AWS Glue install steps are not documented on any live docs page. CHECK WITH SONAL before publishing this tab.**
-{% endtab %}
-
-{% tab title="GCP Dataproc" %}
-_**CHECK WITH SONAL - - NEED TEAMS HELP TO CHECK WHAT EXACTLY FROM THE GCS GUIDE TO BE ADDED HERE**_
-{% endtab %}
-
-{% tab title="Azure Synapse" %}
-**CHECK WITH SONAL - if "Zingg on Azure Synapse" is the same as "Databricks installation instructions" above. Are the install method and library setup are the same.**
-{% endtab %}
-
 {% tab title="Local Spark" %}
 {% hint style="success" icon="right-long" %}
 Docker is the fastest way to get started locally. Use installing from release if you need a specific Spark version or want to integrate with an existing Spark installation.
@@ -255,7 +243,6 @@ This builds Zingg models and finds duplicates in `examples/febrl/test.csv`. You 
 Enterprise only. Zingg on Snowflake uses the Enterprise Snowflake package and runs natively inside Snowflake using Snowpark — no Spark cluster required.
 {% endhint %}
 
-**CHECK WITH SONAL** - Snowflake Enterprise install is referenced at\
 docs.zingg.ai/latest/stepbystep/installation/installing-zingg-enterprise-snowflake
 
 ### **Prerequisites**

--- a/docs/running-zingg/knowledge-graph.md
+++ b/docs/running-zingg/knowledge-graph.md
@@ -30,8 +30,6 @@ The Knowledge Graph is a post-match feature. The sequence is:
 3. The knowledge graph layer maps edges between nodes based on shared attributes, transactions, or relationships defined by your data model.
 4. Query the graph to find connected entities, paths between nodes, and clusters of related records.
 
-_**CHECK WITH TEAM/SONAL—Knowledge Graph is confirmed as an Enterprise Plus feature on the compare-versions page but is not yet documented on any live docs page. Please provide:**_
-
 1. _**How the Knowledge Graph is configured and invoked**_
 2. _**The graph database or format used (Neo4j, native graph store?)**_
 3. _**A worked example showing node and edge definition**_

--- a/docs/running-zingg/label-training-pairs.md
+++ b/docs/running-zingg/label-training-pairs.md
@@ -99,7 +99,6 @@ zingg.initAndExecute()
 Enterprise provides a visual widget showing one pair at a time with Match, No Match, and Can't Say buttons. Download the diagnostics view to share match quality with stakeholders before committing to training.
 {% endhint %}
 
-_**CHECK WITH SONAL - Please confirm the exact Python code for the interactive label widget and saveMarkedRecords() call so this tab can be completed.**_
 {% endtab %}
 
 {% tab title="Enterprise Snowflake" %}

--- a/docs/running-zingg/lookup-data.md
+++ b/docs/running-zingg/lookup-data.md
@@ -58,8 +58,6 @@ This is useful for operational post-match queries: looking up a new customer rec
 
 </details>
 
-**CHECK WITH SONAL -** [**https://docs.zingg.ai/latest/stepbystep/lookup**](https://docs.zingg.ai/latest/stepbystep/lookup) **-**
-
 **The lookup page on the live docs is minimal. Three things to confirm before publishing:**
 
 1. **What does the output look like? Which columns appear in lookup output?**

--- a/docs/running-zingg/run-the-match-phase.md
+++ b/docs/running-zingg/run-the-match-phase.md
@@ -101,7 +101,6 @@ Enterprise output includes `Zingg ID` (persistent across runs) instead of `Z_CLU
 Enterprise only. Zingg on Snowflake uses Snowpark and does not require a Spark cluster.
 {% endhint %}
 
-
 ### CLI
 
 ```bash

--- a/docs/setup/hardwareSizing.md
+++ b/docs/setup/hardwareSizing.md
@@ -21,5 +21,4 @@ Here are some performance numbers you can use to determine the appropriate hardw
 * 80m records with 8-10 fields took less than 2 hours on 1 driver (128 GB RAM, 32 cores), 8 workers (224 GB RAM, 64 cores). This is a user-reported stat without any optimization.
 * <img width="2271" height="1091" alt="image" src="https://github.com/user-attachments/assets/4dadeb56-9d66-4ed2-be6e-e0f0b9ab68c6" />
 
-
 If you have up to a few million records, it may be easier to run Zingg on a single machine in Spark local mode.

--- a/docs/stepbystep/configuration/adv-matchtypes.md
+++ b/docs/stepbystep/configuration/adv-matchtypes.md
@@ -14,9 +14,7 @@ To leverage user expertise for nicknames for example, the user can supply Zingg 
 
 Here is the structure of the json:
 
-
-
-<pre class="language-json"><code class="lang-json"><strong>[  
+<pre class="language-json"><code class="lang-json"><strong>[
 </strong>  ["Will", "Bill", "William"],
   ["John", "Johnny", "Jack"],
   ["Robert", "Rob", "Bob", "Bobby"],
@@ -24,7 +22,7 @@ Here is the structure of the json:
   ["James", "Jim", "Jimmy"],
   ["Thomas", "Tom", "Tommy"]
 ...
-]   
+]
 </code></pre>
 
 Each line here represents common nicknames which represent the same name.&#x20;
@@ -45,10 +43,10 @@ To use this mapping within Zingg, define the field's match type as `MAPPING_<fil
 
 The `MAPPING` match type can also be used to transform and normalise categorical data. Let us say different data sources have different representations of gender. In one, gender is represented as M and F, in another it is noted as Male, Female and in the third as 1 and 2. Instead of transforming the gender column beforehand, one could create a mapping json called `gender.json` .&#x20;
 
-<pre><code><strong>[  
+<pre><code><strong>[
 </strong>  ["M", "Male", "1"],
   ["F", "Female", "2"]
-]  
+]
 </code></pre>
 
 When we use it for the gender field like below, Zingg would automatically handle the transformation so that you don't have to.&#x20;

--- a/docs/stepbystep/configuration/field-definitions.md
+++ b/docs/stepbystep/configuration/field-definitions.md
@@ -47,5 +47,4 @@ Type of the column - `string, integer, double`, etc.
 | ONLY_ALPHABETS_FUZZY_OPTIMISED | Same semantics as ONLY_ALPHABETS_FUZZY but uses optimized processing. Use this when you need the fuzzy alphabet-only behavior at production scale. [Zingg Enterprise Feature](#user-content-fn-1)[^1]                                                                                                                                            | string                                             |
 |             MAPPING_(FILENAME) | Maps input values to canonical values using a mapping file (e.g., nickname maps, company abbreviations, gender codes). Matching is tolerant to common variations defined in the mapping. See [Advanced Match Types](adv-matchtypes.md) for mapping file format and examples.                   | string                                             |
 
-
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to https://www.zingg.ai/product/zingg-entity-resolution-compare-versions for individual tier features.

--- a/docs/stepbystep/createtrainingdata/modeldiff.md
+++ b/docs/stepbystep/createtrainingdata/modeldiff.md
@@ -34,7 +34,6 @@ The diff phase analyzes both outputs and identifies:
 - **New clusters** created in the updated model
 - **Merged or split clusters** between the two models
 
-
 ## Usage
 
 ### Command Line
@@ -169,7 +168,7 @@ This wrapper configuration points to your new configuration and specifies where 
 }
 ```
 
-**Note**: 
+**Note**:
 - This wrapper only points to the new configuration. The original/baseline configuration is specified via the `--compareTo` command-line parameter.
 - The `name` field in `transformedOutputPath` can be any arbitrary identifier for the output pipe - it's used internally by Zingg to identify this output destination. Here we use `diffOutput` to clearly distinguish it from the new model's match output.
 
@@ -406,7 +405,6 @@ The diff output includes:
 - **ZINGG_ID_UPDATED**: ZINGG ID from the new/updated model
 - **ZINGG_ID_ORIGINAL**: ZINGG ID from the original/baseline model
 
-
 This allows you to see side-by-side how each record's cluster assignment changed between the two models.
 
 ##  Enhanced Diff Output with Outer Join
@@ -415,7 +413,6 @@ We're developing an enhanced diff that will provide even more comprehensive comp
 
 - **All records from both models**, including those that appear in only one output
 - **Enhanced null handling**: Intelligent merging of primary key columns when records appear in only one model
-
 
 ## Use Cases
 
@@ -436,6 +433,5 @@ Ensure that model updates don't accidentally degrade match quality for specific 
 
 ### 6. Configuration Tuning
 Experiment with different labelDataSampleSize, numPartitions, or other parameters and see the impact.
-
 
 [^1]: Zingg Enterprise is the suite of proprietary products licensed by Zingg. Please refer to https://www.zingg.ai/product/zingg-entity-resolution-compare-versions for individual tier features.

--- a/docs/tuning/configure-field-standardization.md
+++ b/docs/tuning/configure-field-standardization.md
@@ -111,9 +111,6 @@ Use `STANDARDISE_<basename>` to reference a mapping file named `<basename>.json`
 {% endhint %}
 {% endtab %}
 
-{% tab title="Enterprise Snowflake" %}
-**CONTENT FOR THIS SECTION TO BE PROVIDED BY SONAL LATER**
-{% endtab %}
 {% endtabs %}
 
 ### **Verify the standardisation in your output**

--- a/docs/tuning/custom-blocking-and-similarity.md
+++ b/docs/tuning/custom-blocking-and-similarity.md
@@ -62,7 +62,4 @@ For similarity, you can define your comparison measures alongside Zingg's built-
 
 You can define your comparison functions and register them so Zingg uses them as additional features for the classifier. The classifier then determines the best weight for each feature, including your custom one, based on your labeled training data.
 
-_**LINK TO BE ADDED -  GitHub Zingg repository custom similarity example (add link to****&#x20;****`github.com/zinggAI/zingg`****&#x20;****once confirmed by team)**_
-
 Custom similarity and blocking function implementation requires Java/Scala code changes to the Zingg JAR. These are advanced customizations. For most use cases, adjusting match types, stopwords, and training data is sufficient before reaching this step.
-

--- a/docs/tuning/improve-accuracy/remove-stopwords-optional.md
+++ b/docs/tuning/improve-accuracy/remove-stopwords-optional.md
@@ -81,6 +81,5 @@ zingg.initAndExecute()
 {% tab title="Enterprise Snowflake" %}
 Stopwords are stored as a table: `zingg_stopWords_columnName_modelId`
 
-**CHECK WITH SONAL ABOUT THIS TOPIC - NEEDS ENTIRELY DIFFERENT SET OF CONTENT TO BE DISCUSSED LATER.**
 {% endtab %}
 {% endtabs %}

--- a/docs/ubuntuSetup.md
+++ b/docs/ubuntuSetup.md
@@ -1,10 +1,8 @@
 # Ubuntu/WSL2 Setup Guide
 
-The following steps will help you set up the Zingg Development Environment on **Ubuntu/WSL2**. 
-
+The following steps will help you set up the Zingg Development Environment on **Ubuntu/WSL2**.
 
 ### **Step 0: Initial OS Setup (Ubuntu/WSL2)**
-
 
 Make sure to update your Ubuntu installation:
 
@@ -82,8 +80,8 @@ Make sure that Spark version you have installed is compatible with Java you have
 
 ```
 wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz
-tar -xvf apache-maven-3.8.8-bin.tar.gz 
-rm -rf apache-maven-3.8.8-bin.tar.gz 
+tar -xvf apache-maven-3.8.8-bin.tar.gz
+rm -rf apache-maven-3.8.8-bin.tar.gz
 cd apache-maven-3.8.8/
 cd bin
 ./mvn --version
@@ -150,7 +148,6 @@ mvn clean compile package -Dspark=sparkVer -Dmaven.test.skip=true
 **Note:** Replace the `sparkVer` with the version of Spark you installed. \
 For example, **-Dspark=3.5** you still face an error, include **-Dmaven.test.skip=true** with the above command.
 
-
 **Step 7: If you have any issue with 'SPARK_LOCAL_IP' (Ubuntu)**
 
 * Install **net-tools** using **sudo apt-get install -y net-tools**
@@ -174,4 +171,3 @@ For example, **-Dspark=3.5** you still face an error, include **-Dmaven.test.ski
 
 * Run this script in the terminal opened in Zingg clones directory `./scripts/zingg.sh --phase match --conf examples/febrl/config.json --properties-file config/zingg.conf`
 * change directory `cd /tmp/zinggOutput` (path provided in config file) to see the output files.
-

--- a/docs/zingg-concepts/how-zingg-learns/match-types/email_optimised-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/email_optimised-match.md
@@ -45,7 +45,6 @@ performance matters. Customer datasets, patient registries, voter files—any do
 
 </details>
 
-
 ### Configuring `EMAIL_OPTIMISED`
 
 {% tabs %}
@@ -60,7 +59,7 @@ email = EFieldDefinition("email", "string", EMatchType.EMAIL_OPTIMISED)
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block below uses Enterprise-only match type `EMAIL_OPTIMISED`. 
+The JSON `fieldDefinition` block below uses Enterprise-only match type `EMAIL_OPTIMISED`.
 {% endhint %}
 
 ```json

--- a/docs/zingg-concepts/how-zingg-learns/match-types/fuzzy-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/fuzzy-match.md
@@ -83,7 +83,6 @@ Use `PINCODE` not `FUZZY` for postal codes. `PINCODE` is built to handle the spe
 
 `FUZZY` is computationally heavier than `FUZZY_OPTIMISED`. For production runs on large datasets where you want the same matching quality with faster results, use `FUZZY_OPTIMISED` instead.
 
-
 </details>
 
 ### Configuring `FUZZY`

--- a/docs/zingg-concepts/how-zingg-learns/match-types/numeric-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/numeric-match.md
@@ -15,7 +15,7 @@ This makes it useful for address fields where a number is embedded in a string -
 
 ### What `NUMERIC` matches and what it does not
 
-<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">42 Main St</td><td valign="top">42 Main Street</td><td valign="top">Yes - 42 extracted from both</td></tr><tr><td valign="top">42B Main St</td><td valign="top">42 Main St</td><td valign="top">Yes - 42 extracted from both (B ignored)</td></tr><tr><td valign="top">42 Main St</td><td valign="top">43 Main St</td><td valign="top">No - different numbers (42 vs 43)</td></tr><tr><td valign="top">Suite 12, Floor 3</td><td valign="top">Suite 12, Floor 4</td><td valign="top">Partial - 12 matches, 3 vs 4 differs. Score reflects partial overlap.</td></tr><tr><td valign="top">Flat 4, Tower A</td><td valign="top">Flat 4, Tower A</td><td valign="top">Yes - 4 matches</td></tr><tr><td valign="top">[no numbers]</td><td valign="top">42 Main St</td><td valign="top"><em><strong>Confirm with team —</strong></em><br><em><strong>what score when one side has no numbers?</strong></em></td></tr></tbody></table>
+<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">42 Main St</td><td valign="top">42 Main Street</td><td valign="top">Yes - 42 extracted from both</td></tr><tr><td valign="top">42B Main St</td><td valign="top">42 Main St</td><td valign="top">Yes - 42 extracted from both (B ignored)</td></tr><tr><td valign="top">42 Main St</td><td valign="top">43 Main St</td><td valign="top">No - different numbers (42 vs 43)</td></tr><tr><td valign="top">Suite 12, Floor 3</td><td valign="top">Suite 12, Floor 4</td><td valign="top">Partial - 12 matches, 3 vs 4 differs. Score reflects partial overlap.</td></tr><tr><td valign="top">Flat 4, Tower A</td><td valign="top">Flat 4, Tower A</td><td valign="top">Yes - 4 matches</td></tr><tr><td valign="top">[no numbers]</td><td valign="top">42 Main St</td><td valign="top">—</td></tr></tbody></table>
 
 ### When to use `NUMERIC`
 
@@ -78,7 +78,7 @@ from zinggEC.enterprise.common.EFieldDefinition import EFieldDefinition
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise). 
+The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise).
 {% endhint %}
 
 ```json

--- a/docs/zingg-concepts/how-zingg-learns/match-types/numeric_with_units-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/numeric_with_units-match.md
@@ -13,7 +13,7 @@ description: >-
 
 ### What `NUMERIC_WITH_UNITS` matches and what it does not
 
-<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">16gb RAM</td><td valign="top">16 GB Memory</td><td valign="top">Yes - 16 GB extracted from both</td></tr><tr><td valign="top">16gb RAM</td><td valign="top">32gb RAM</td><td valign="top">No - different numbers</td></tr><tr><td valign="top">500ml</td><td valign="top">0.5L</td><td valign="top"><em><strong>Confirm with team —</strong></em><br><em><strong>unit normalisation (ml vs L</strong></em>)</td></tr><tr><td valign="top">2.4GHz Dual Core</td><td valign="top">2.4GHz Processor</td><td valign="top">Yes - 2.4GHz matches</td></tr><tr><td valign="top">16gb</td><td valign="top">16</td><td valign="top">Confirm - with vs without unit</td></tr></tbody></table>
+<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">16gb RAM</td><td valign="top">16 GB Memory</td><td valign="top">Yes - 16 GB extracted from both</td></tr><tr><td valign="top">16gb RAM</td><td valign="top">32gb RAM</td><td valign="top">No - different numbers</td></tr><tr><td valign="top">500ml</td><td valign="top">0.5L</td><td valign="top">—)</td></tr><tr><td valign="top">2.4GHz Dual Core</td><td valign="top">2.4GHz Processor</td><td valign="top">Yes - 2.4GHz matches</td></tr><tr><td valign="top">16gb</td><td valign="top">16</td><td valign="top">Confirm - with vs without unit</td></tr></tbody></table>
 
 ### When to use `NUMERIC_WITH_UNIT`
 
@@ -58,7 +58,7 @@ from zinggEC.enterprise.common.EFieldDefinition import EFieldDefinition
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise). 
+The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise).
 {% endhint %}
 
 ```json

--- a/docs/zingg-concepts/how-zingg-learns/match-types/only_alphabets_fuzzy-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/only_alphabets_fuzzy-match.md
@@ -11,7 +11,6 @@ description: >-
 
 `ONLY_ALPHABETS_FUZZY` removes all numeric characters from both field values and then applies fuzzy string similarity to the remaining alphabetic characters. Two values match based on how similar their alphabetic portions are with tolerance for typos, abbreviations, and spelling variants.
 
-
 ### What **`ONLY_ALPHABETS_FUZZY`** matches and what it does not
 
 <table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">42 Main Street</td><td valign="top">44 Main Street</td><td valign="top">Yes - numbers stripped, "Main Street" is identical</td></tr><tr><td valign="top">42 Main St</td><td valign="top">44 Main Street</td><td valign="top">Yes - "Main St" vs "Main Street" scores a high fuzzy similarity</td></tr><tr><td valign="top">42 Main St</td><td valign="top">42 Oak St</td><td valign="top">No - "Main St" vs "Oak St" too different alphabetically</td></tr><tr><td valign="top">[null]</td><td valign="top">Main Street</td><td valign="top">Yes - a null/blank value on either side is an automatic match; add <code>NULL_OR_BLANK</code> if you want nulls excluded</td></tr></tbody></table>
@@ -115,7 +114,7 @@ street = EFieldDefinition("street", "string", MatchType.ONLY_ALPHABETS_FUZZY)
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise). 
+The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise).
 {% endhint %}
 
 ```json
@@ -137,7 +136,7 @@ The JSON `fieldDefinition` block is identical for Community and Enterprise. Only
 
 * `NUMERIC` - use this for numeric fields
 * `ONLY_ALPHABETS_EXACT` - use when the name must match exactly (no abbreviation tolerance)
-* `ONLY_ALPHABETS_FUZZY_OPTIMISED` - same match type, faster at scale 
+* `ONLY_ALPHABETS_FUZZY_OPTIMISED` - same match type, faster at scale
 * `FUZZY` - simpler alternative for the full string
 
 **Read more**: [Match Types](README.md)

--- a/docs/zingg-concepts/how-zingg-learns/match-types/pincode-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/pincode-match.md
@@ -15,7 +15,7 @@ It is more permissive than `EXACT` (which would not match "94102" and "94102-123
 
 ### What `PINCODE` matches and what it does not
 
-<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">94102</td><td valign="top">94102-1234</td><td valign="top">Yes - 5-digit and ZIP+4 same base</td></tr><tr><td valign="top">94102</td><td valign="top">94103</td><td valign="top">No - different postal codes</td></tr><tr><td valign="top">EC1A 1BB</td><td valign="top">EC1A1BB</td><td valign="top"><em><strong>Confirm with team —</strong></em><br><em><strong>UK postcode with/without space</strong></em></td></tr><tr><td valign="top">110001</td><td valign="top">110001</td><td valign="top">Yes - Indian PIN code, identical</td></tr><tr><td valign="top">94102</td><td valign="top">941-02</td><td valign="top"><em><strong>Confirm with team —</strong></em><br><em><strong>hyphen in different position</strong></em></td></tr><tr><td valign="top">[null]</td><td valign="top">94102</td><td valign="top"><em><strong>Confirm — add NULL_OR_BLANK to control null behaviour</strong></em></td></tr></tbody></table>
+<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">94102</td><td valign="top">94102-1234</td><td valign="top">Yes - 5-digit and ZIP+4 same base</td></tr><tr><td valign="top">94102</td><td valign="top">94103</td><td valign="top">No - different postal codes</td></tr><tr><td valign="top">EC1A 1BB</td><td valign="top">EC1A1BB</td><td valign="top">—</td></tr><tr><td valign="top">110001</td><td valign="top">110001</td><td valign="top">Yes - Indian PIN code, identical</td></tr><tr><td valign="top">94102</td><td valign="top">941-02</td><td valign="top">—</td></tr><tr><td valign="top">[null]</td><td valign="top">94102</td><td valign="top"><em><strong>Confirm — add NULL_OR_BLANK to control null behaviour</strong></em></td></tr></tbody></table>
 
 ### When to use `PINCODE`
 
@@ -60,7 +60,7 @@ from zinggEC.enterprise.common.EFieldDefinition import EFieldDefinition
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise). 
+The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise).
 {% endhint %}
 
 ```json

--- a/docs/zingg-concepts/how-zingg-learns/match-types/text-match.md
+++ b/docs/zingg-concepts/how-zingg-learns/match-types/text-match.md
@@ -15,7 +15,7 @@ description: >-
 
 ### What `TEXT` matches and what it does not
 
-<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">Enterprise data management platform</td><td valign="top">Data management platform for enterprise</td><td valign="top">Yes - high word overlap<br>("enterprise", "data", "management",<br>"platform" all shared)</td></tr><tr><td valign="top">Enterprise software solutions</td><td valign="top">Consumer hardware products</td><td valign="top">No - low word overlap</td></tr><tr><td valign="top">Machine learning model training</td><td valign="top">Training machine learning models</td><td valign="top">Yes - same words, different order</td></tr><tr><td valign="top">ML model</td><td valign="top">Machine learning model</td><td valign="top">Partial - "model" shared,<br>"ML" vs "Machine learning" differs. Score reflects partial overlap.</td></tr><tr><td valign="top">[empty]</td><td valign="top">Enterprise data platform</td><td valign="top"><em><strong>Confirm with team —</strong></em><br><em><strong>empty string behaviour</strong></em></td></tr><tr><td valign="top"></td><td valign="top"></td><td valign="top"></td></tr></tbody></table>
+<table><thead><tr><th valign="top">Value A</th><th valign="top">Value B</th><th valign="top">Match?</th></tr></thead><tbody><tr><td valign="top">Enterprise data management platform</td><td valign="top">Data management platform for enterprise</td><td valign="top">Yes - high word overlap<br>("enterprise", "data", "management",<br>"platform" all shared)</td></tr><tr><td valign="top">Enterprise software solutions</td><td valign="top">Consumer hardware products</td><td valign="top">No - low word overlap</td></tr><tr><td valign="top">Machine learning model training</td><td valign="top">Training machine learning models</td><td valign="top">Yes - same words, different order</td></tr><tr><td valign="top">ML model</td><td valign="top">Machine learning model</td><td valign="top">Partial - "model" shared,<br>"ML" vs "Machine learning" differs. Score reflects partial overlap.</td></tr><tr><td valign="top">[empty]</td><td valign="top">Enterprise data platform</td><td valign="top">—</td></tr><tr><td valign="top"></td><td valign="top"></td><td valign="top"></td></tr></tbody></table>
 
 ### When to use `TEXT`
 
@@ -79,7 +79,7 @@ from zinggEC.enterprise.common.EFieldDefinition import EFieldDefinition
 
 {% tab title="JSON" %}
 {% hint style="info" icon="right-long" %}
-The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise). 
+The JSON `fieldDefinition` block is identical for Community and Enterprise. Only the Python class differs between editions — `FieldDefinition` (Community) vs `EFieldDefinition` (Enterprise).
 {% endhint %}
 
 ```json

--- a/docs/zingg-concepts/pass-through.md
+++ b/docs/zingg-concepts/pass-through.md
@@ -84,9 +84,6 @@ For nullable fields, ensure the negative of your expression correctly identifies
 Zingg internally applies the negation of `passthroughExpr` to filter which records participate in matching. If you apply the condition to a nullable field without the null guard, records with null values in that field may behave unexpectedly.
 {% endtab %}
 
-{% tab title="Enterprise Snowflake" %}
-_**CHECK WITH SONAL - Enterprise Snowflake content for this topic to be provivded by Sonal**_
-{% endtab %}
 {% endtabs %}
 
 ### Pass Through records in the output


### PR DESCRIPTION
## What
Removes leaked internal review notes that were shipped to the published docs.

## Why
Several pages carried editorial placeholders never meant to be public — internal review notes, teammate call-outs, and "to be added" markers visible on the live site and in the page source / Markdown exports.

## Changes
Removed across 60 pages:
- `CHECK WITH SONAL` / `CHECK WITH TEAM` review notes
- `IMAGE TO BE ADDED` screenshot placeholders (platform guides)
- `COMMENT FOR TEAM` algorithm-detail placeholders (match-type pages)
- `CONTENT TO BE GIVEN` / `CONTENT FOR THIS SECTION` stubs
- `Confirm with team` notes embedded in edge-case tables (neutralized to keep the tables intact)
- Stray `LINK TO BE ADDED` markers

Handling:
- Stray note lines were deleted.
- Where a note was the only content under a heading, the empty heading was removed too.
- Empty "Enterprise Snowflake" tabs were replaced with a neutral one-line pointer so the tab structure stays valid.

No content or behavior changes — this PR only strips the internal notes.
