### PR TITLE
docs: standardize zingg.sh invocation to ./scripts/zingg.sh

### DIFF
--- a/docs/Transform.md
+++ b/docs/Transform.md
@@ -148,7 +148,7 @@ Use `STANDARDISE_<basename>` to reference a mapping file named `<basename>.json`
 Run the Transform phase with the following command:
 
 ```bash
-scripts/zingg.sh --phase transform --conf examples/febrl/config.json --properties-file config/zingg.conf
+./scripts/zingg.sh --phase transform --conf examples/febrl/config.json --properties-file config/zingg.conf
 ```
 
 This will:

--- a/docs/frequently-asked-questions/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions/frequently-asked-questions.md
@@ -66,7 +66,7 @@ Check blocking first. Run `verifyBlocking` to confirm your known matching pairs 
 
 <summary><strong>Can I use Zingg without writing any code?</strong></summary>
 
-Yes, using the JSON config file and CLI. Define your field definitions, data source, and output in config.json, then run each phase with `./zingg.sh --phase <phase_name> --conf config.json`. No Python code required.
+Yes, using the JSON config file and CLI. Define your field definitions, data source, and output in config.json, then run each phase with `./scripts/zingg.sh --phase <phase_name> --conf config.json`. No Python code required.
 
 </details>
 

--- a/docs/recipes-and-integration/pre-trained-models.md
+++ b/docs/recipes-and-integration/pre-trained-models.md
@@ -104,7 +104,7 @@ zingg.initAndExecute()
 Skip `findTrainingData` and `label`. Run `match` directly using the pre-trained model.
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 {% hint style="success" icon="right-long" %}

--- a/docs/reference/zingg-command-line.md
+++ b/docs/reference/zingg-command-line.md
@@ -37,7 +37,7 @@ Replace `config.json` with your actual config file path.
 ### **Find training pairs**
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json
+./scripts/zingg.sh --phase findTrainingData --conf config.json
 ```
 
 ### **Label pairs**
@@ -45,13 +45,13 @@ Replace `config.json` with your actual config file path.
 The `--showConcise=true` flag shows only fields used for matching and hides `DONT_USE` fields.
 
 ```bash
-./zingg.sh --phase label --conf config.json --showConcise=true
+./scripts/zingg.sh --phase label --conf config.json --showConcise=true
 ```
 
 ### Train the model
 
 ```bash
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```
 
 ### **Run match**
@@ -59,7 +59,7 @@ The `--showConcise=true` flag shows only fields used for matching and hides `DON
 `match` finds duplicates within a single dataset.
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 ### **Run link**
@@ -67,7 +67,7 @@ The `--showConcise=true` flag shows only fields used for matching and hides `DON
 `link` matches records across two separate datasets.
 
 ```bash
-./zingg.sh --phase link --conf config.json
+./scripts/zingg.sh --phase link --conf config.json
 ```
 {% endtab %}
 
@@ -80,13 +80,13 @@ Enterprise adds two phases not available in Community: `generateDoc`s and\
 ### Find training pairs
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json
+./scripts/zingg.sh --phase findTrainingData --conf config.json
 ```
 
 ### Label pairs
 
 ```bash
-./zingg.sh --phase label --conf config.json --showConcise=true
+./scripts/zingg.sh --phase label --conf config.json --showConcise=true
 ```
 
 ### **Generate model documentation**
@@ -94,25 +94,25 @@ Enterprise adds two phases not available in Community: `generateDoc`s and\
 Optional but recommended before `train` — lets you inspect training data quality before committing to the train phase.
 
 ```bash
-./zingg.sh --phase generateDocs --conf config.json
+./scripts/zingg.sh --phase generateDocs --conf config.json
 ```
 
 ### Train the model
 
 ```bash
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```
 
 ### Run match
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 ### Run link
 
 ```bash
-./zingg.sh --phase link --conf config.json
+./scripts/zingg.sh --phase link --conf config.json
 ```
 
 ### **Run incremental**
@@ -120,7 +120,7 @@ Optional but recommended before `train` — lets you inspect training data quali
 Updates the identity graph with new and changed records without re-running the full match.
 
 ```bash
-./zingg.sh --phase runIncremental --conf config.json
+./scripts/zingg.sh --phase runIncremental --conf config.json
 ```
 
 {% hint style="info" icon="right-long" %}

--- a/docs/running-zingg/build-and-save-the-model.md
+++ b/docs/running-zingg/build-and-save-the-model.md
@@ -32,7 +32,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```
 {% endtab %}
 
@@ -51,7 +51,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```
 
 Enterprise adds blocking model configuration via `args.setBlockingModel()`. Set this in Configure Zingg before running `train`.
@@ -71,7 +71,7 @@ Enterprise only. Zingg on Snowflake uses Snowpark and does not require a Spark c
 ### CLI
 
 ```bash
-./zingg.sh --phase train --conf config.json \
+./scripts/zingg.sh --phase train --conf config.json \
 --properties-file <location to snowflake.properties>
 ```
 

--- a/docs/running-zingg/create-training-data.md
+++ b/docs/running-zingg/create-training-data.md
@@ -25,7 +25,7 @@ args.setLabelDataSampleSize(0.5)
 ### Run findTrainingData
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json
+./scripts/zingg.sh --phase findTrainingData --conf config.json
 ```
 
 #### Using Python API
@@ -92,7 +92,7 @@ zingg.initAndExecute()
 #### CLI
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json
+./scripts/zingg.sh --phase findTrainingData --conf config.json
 ```
 
 {% hint style="info" icon="right-long" %}
@@ -114,11 +114,11 @@ Candidate pairs are written to `zinggDir/modelId`. Run the label phase next to r
 #### CLI
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json \
+./scripts/zingg.sh --phase findTrainingData --conf config.json \
 --properties-file <location to snowflake.properties>
 ```
 
-<!-- 
+<!--
 #### JSON
 
 ```json

--- a/docs/running-zingg/label-training-pairs.md
+++ b/docs/running-zingg/label-training-pairs.md
@@ -50,7 +50,7 @@ zingg.initAndExecute()
 ### **CLI**
 
 ```bash
-./zingg.sh --phase label --conf config.json --showConcise=true
+./scripts/zingg.sh --phase label --conf config.json --showConcise=true
 ```
 
 {% hint style="success" icon="right-long" %}
@@ -110,7 +110,7 @@ The `showConcise` flag only shows fields which are `NOT DONT_USE`. This makes th
 #### CLI
 
 ```bash
-./zingg.sh --phase label --conf config.json --showConcise=true \ --properties-file <location to snowflake.properties>
+./scripts/zingg.sh --phase label --conf config.json --showConcise=true \ --properties-file <location to snowflake.properties>
 ```
 
 {% hint style="info" icon="right-long" %}

--- a/docs/running-zingg/link-across-datasets.md
+++ b/docs/running-zingg/link-across-datasets.md
@@ -42,7 +42,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase link --conf config.json
+./scripts/zingg.sh --phase link --conf config.json
 ```
 
 {% hint style="success" icon="right-long" %}
@@ -76,7 +76,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase link --conf config.json
+./scripts/zingg.sh --phase link --conf config.json
 ```
 
 ### Read and View Output
@@ -103,7 +103,7 @@ Enterprise only. Zingg on Snowflake uses Snowpark and does not require a Spark c
 ### CLI
 
 ```bash
-./zingg.sh --phase link --conf config.json \
+./scripts/zingg.sh --phase link --conf config.json \
 --properties-file <location to snowflake.properties>
 ```
 

--- a/docs/running-zingg/quick-start-docker.md
+++ b/docs/running-zingg/quick-start-docker.md
@@ -112,7 +112,7 @@ args.setData(inputPipe)
 
 outputPipe = CsvPipe("resultFebrl", "/tmp/febrlOutput")
 args.setOutput(outputPipe)
-                                                        
+
 ```
 
 #### Python - Enterprise
@@ -298,16 +298,16 @@ zingg.initAndExecute()
 #### **Python - Enterprise**
 
 ```python
-options = ClientOptions([ ClientOptions.PHASE, "findTrainingData" ]) 
+options = ClientOptions([ ClientOptions.PHASE, "findTrainingData" ])
 
-zingg = EZingg(args, options) 
+zingg = EZingg(args, options)
 zingg.initAndExecute()
 ```
 
 #### CLI (both editions)
 
 ```bash
-./zingg.sh --phase findTrainingData --conf config.json
+./scripts/zingg.sh --phase findTrainingData --conf config.json
 ```
 
 ### **Step 5: Label pairs**
@@ -325,7 +325,7 @@ Zingg selects the most informative pairs from your data - not random samples. La
 #### **Python - Community**
 
 ```python
-options = ClientOptions([ ClientOptions.PHASE, "label" ]) 
+options = ClientOptions([ ClientOptions.PHASE, "label" ])
 zingg = Zingg(args, options)
 zingg.initAndExecute()
 ```
@@ -341,7 +341,7 @@ zingg.initAndExecute()
 #### CLI (both editions)
 
 ```bash
-./zingg.sh --phase label --conf config.json --showConcise=true
+./scripts/zingg.sh --phase label --conf config.json --showConcise=true
 ```
 
 The `--showConcise=true` flag shows only fields used for matching and hides `DONT_USE` fields.
@@ -371,7 +371,7 @@ zingg.initAndExecute()
 #### CLI (both editions)
 
 ```bash
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```
 
 ### **Step 7: Run match and resolve identities**
@@ -392,14 +392,14 @@ zingg.initAndExecute()
 ```python
 options = ClientOptions([ ClientOptions.PHASE, "match" ])
 
-zingg = EZingg(args, options) 
+zingg = EZingg(args, options)
 zingg.initAndExecute()
 ```
 
 #### CLI (both editions)
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 ### **Reading the match output**

--- a/docs/running-zingg/run-the-match-phase.md
+++ b/docs/running-zingg/run-the-match-phase.md
@@ -42,7 +42,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 ### Read and View Output
@@ -77,7 +77,7 @@ zingg.initAndExecute()
 ### CLI
 
 ```bash
-./zingg.sh --phase match --conf config.json
+./scripts/zingg.sh --phase match --conf config.json
 ```
 
 ### Read and View Output
@@ -105,7 +105,7 @@ Enterprise only. Zingg on Snowflake uses Snowpark and does not require a Spark c
 ### CLI
 
 ```bash
-./zingg.sh --phase match --conf config.json \
+./scripts/zingg.sh --phase match --conf config.json \
 --properties-file <location to snowflake.properties>
 ```
 

--- a/docs/setup/link.md
+++ b/docs/setup/link.md
@@ -8,7 +8,7 @@ nav_order: 11
 
 In many cases like reference data mastering, enrichment, etc, two individual datasets are duplicate-free but they need to be matched against each other. The link phase is used for such scenarios.
 
-`./zingg.sh --phase link --conf config.json`
+`./scripts/zingg.sh --phase link --conf config.json`
 
 Sample configuration file [configLink.json](../../examples/febrl/configLink.json) is defined at [examples/febrl](https://github.com/zinggAI/zingg/tree/main/examples/febrl). In this option, each record from the first source is matched with all the records from the remaining sources.
 

--- a/docs/setup/match.md
+++ b/docs/setup/match.md
@@ -7,7 +7,7 @@ description: Finds the records that match with each other.
 
 # Finding The Matches
 
-`./zingg.sh --phase match --conf config.json`
+`./scripts/zingg.sh --phase match --conf config.json`
 
 As can be seen in the image below, matching records are given the same **z\_cluster** id/Zingg ID in the case of Zingg Enterprise. Each record also gets a **z\_minScore** and **z\_maxScore** which shows the _least/greatest_ it matched with other records in the same cluster.
 

--- a/docs/setup/train.md
+++ b/docs/setup/train.md
@@ -10,5 +10,5 @@ description: So that the same model can be applied to new data
 Builds up the Zingg models using the training data from the above phases and writes them to the folder **zinggDir/modelId** as specified in the config.
 
 ```
-./zingg.sh --phase train --conf config.json
+./scripts/zingg.sh --phase train --conf config.json
 ```

--- a/docs/setup/training/findAndLabel.md
+++ b/docs/setup/training/findAndLabel.md
@@ -9,6 +9,6 @@ nav_order: 2
 
 This phase is composed of two phases namely [findTrainingData](findTrainingData.md) and [label](label.md). This will help experienced users to quicken the process of creating training data.
 
-`./zingg.sh --phase findAndLabel --conf config.json`
+`./scripts/zingg.sh --phase findAndLabel --conf config.json`
 
 As this is phase runs **findTrainingData** and **label** together, it should be run only for small datasets where **findTrainingData** takes a short time to run, else the the user will have to wait long for the console to label.

--- a/docs/setup/training/findTrainingData.md
+++ b/docs/setup/training/findTrainingData.md
@@ -11,6 +11,6 @@ The **findTrainingData** phase prompts Zingg to search for edge cases in the dat
 
 This **findTrainingData** job writes the edge cases to the folder configured through `zinggDir/modelId` in the config:
 
-`./zingg.sh --phase findTrainingData --conf config.json`
+`./scripts/zingg.sh --phase findTrainingData --conf config.json`
 
 The **findTrainingData** phase is run first and then the label phase is run and this cycle is repeated so that the Zingg models get smarter from user feedback.

--- a/docs/setup/training/label.md
+++ b/docs/setup/training/label.md
@@ -9,7 +9,7 @@ description: Providing user feedback on the training pairs
 
 The label phase opens an _interactive_ learner where the user can mark the pairs found by **findTrainingData** phase as matches or non-matches. The **findTrainingData** phase generates edge cases for labeling and the label phase helps the user mark them.
 
-`./zingg.sh --phase label --conf config.json <optional --showConcise=true|false>`
+`./scripts/zingg.sh --phase label --conf config.json <optional --showConcise=true|false>`
 
 Proceed running **findTrainingData** followed by label phases till you have at least 30-40 positives, and when you see the predictions by Zingg converging with the output you want. At each stage, the user will get different variations of attributes across the records. Zingg performs pretty well with even a small number of training, as the samples to be labeled are chosen by the algorithm itself.
 


### PR DESCRIPTION
## What
Standardizes the run command in the docs to `./scripts/zingg.sh`.

## Why
The docs mixed `./zingg.sh` (34 occurrences) with the correct `./scripts/zingg.sh`. There is no `zingg.sh` at the repo root — the script lives at `scripts/zingg.sh` — so `./zingg.sh` fails with "No such file or directory" when copied from the repo root. The repo's own README and examples use `./scripts/zingg.sh`.

## Changes
- `./zingg.sh` -> `./scripts/zingg.sh`
- bare `scripts/zingg.sh` -> `./scripts/zingg.sh`
- 16 pages updated; the bare `zingg.sh` form (valid on PATH inside the Docker image) is left as-is.

The Snowflake platform guide is intentionally excluded (handled by a separate rewrite).
