### PR TITLE
Add SparkDocumenter executor test (#1304)

### DIFF
--- a/common/core/src/test/java/zingg/common/core/documenter/TestDocumenterExecutorBase.java
+++ b/common/core/src/test/java/zingg/common/core/documenter/TestDocumenterExecutorBase.java
@@ -1,0 +1,85 @@
+package zingg.common.core.documenter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.rmi.NoSuchObjectException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import zingg.common.client.ClientOptions;
+import zingg.common.client.arguments.ArgumentServiceImpl;
+import zingg.common.client.arguments.IArgumentService;
+import zingg.common.client.arguments.model.Arguments;
+import zingg.common.client.arguments.model.IArguments;
+import zingg.common.client.pipe.FilePipe;
+import zingg.common.client.pipe.Pipe;
+import zingg.common.client.ZinggClientException;
+import zingg.common.core.context.Context;
+import zingg.common.core.executor.Documenter;
+
+/**
+ * Tests the Documenter executor end to end: running {@link Documenter#execute()}
+ * against a prepared model fixture should produce both the model and data HTML
+ * documents on disk.
+ */
+public abstract class TestDocumenterExecutorBase<S, D, R, C, T> {
+
+    public static final Log LOG = LogFactory.getLog(TestDocumenterExecutorBase.class);
+
+    protected Context<S, D, R, C, T> context;
+    protected IArguments docArguments = new Arguments();
+
+    public TestDocumenterExecutorBase() {
+    }
+
+    public void initialize(Context<S, D, R, C, T> context) throws ZinggClientException {
+        this.context = context;
+    }
+
+    /** each engine (Spark, etc.) supplies its own initialised executor */
+    protected abstract Documenter<S, D, R, C, T> getDocumenter() throws ZinggClientException;
+
+    @BeforeEach
+    public void setUp() throws NoSuchObjectException, ZinggClientException {
+        String configPath = getClass().getResource("../../../../documenter/config.json").getFile();
+        IArgumentService<Arguments> argsUtil = new ArgumentServiceImpl<>(Arguments.class);
+        docArguments = argsUtil.loadArguments(configPath);
+        // point zinggDir at the prepared model fixture under test resources
+        String zinggDirPath = getClass().getResource("../../../../" + docArguments.getZinggDir()).getFile();
+        docArguments.setZinggDir(zinggDirPath);
+        // point the input data at the test csv so the data document is generated
+        Pipe[] dataPipeArr = docArguments.getData();
+        String dataFile = getClass().getResource("../../../../documenter/test.csv").getFile();
+        for (int i = 0; i < dataPipeArr.length; i++) {
+            dataPipeArr[i].setProp(FilePipe.PATH, dataFile);
+        }
+    }
+
+    @Test
+    public void testExecuteGeneratesModelAndDataDocuments() throws Throwable {
+        Documenter<S, D, R, C, T> documenter = getDocumenter();
+
+        String modelDocFile = documenter.getModelHelper().getZinggModelDocFile(docArguments);
+        String dataDocFile = documenter.getModelHelper().getZinggDataDocFile(docArguments);
+
+        // start clean so a stale file from a previous run cannot make the test lie
+        Files.deleteIfExists(Paths.get(modelDocFile));
+        Files.deleteIfExists(Paths.get(dataDocFile));
+
+        try {
+            documenter.execute();
+
+            assertTrue(Files.exists(Paths.get(modelDocFile)), "model document was not generated");
+            assertTrue(Files.exists(Paths.get(dataDocFile)), "data document was not generated");
+        } finally {
+            // do not leave generated documents behind in the source tree
+            Files.deleteIfExists(Paths.get(modelDocFile));
+            Files.deleteIfExists(Paths.get(dataDocFile));
+        }
+    }
+}

--- a/spark/core/src/test/java/zingg/spark/core/documenter/TestSparkDocumenterExecutor.java
+++ b/spark/core/src/test/java/zingg/spark/core/documenter/TestSparkDocumenterExecutor.java
@@ -1,0 +1,44 @@
+package zingg.spark.core.documenter;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataType;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import zingg.common.client.ClientOptions;
+import zingg.common.client.ZinggClientException;
+import zingg.common.core.documenter.TestDocumenterExecutorBase;
+import zingg.common.core.executor.Documenter;
+import zingg.spark.core.TestSparkBaseLite;
+import zingg.spark.core.context.ZinggSparkContext;
+import zingg.spark.core.executor.SparkDocumenter;
+
+@ExtendWith(TestSparkBaseLite.class)
+public class TestSparkDocumenterExecutor
+        extends TestDocumenterExecutorBase<SparkSession, Dataset<Row>, Row, Column, DataType> {
+
+    public static final Log LOG = LogFactory.getLog(TestSparkDocumenterExecutor.class);
+
+    private final SparkSession sparkSession;
+    private final ZinggSparkContext zinggSparkContext;
+
+    public TestSparkDocumenterExecutor(SparkSession sparkSession) throws ZinggClientException {
+        this.sparkSession = sparkSession;
+        this.zinggSparkContext = new ZinggSparkContext();
+        zinggSparkContext.init(sparkSession);
+        initialize(zinggSparkContext);
+    }
+
+    @Override
+    protected Documenter<SparkSession, Dataset<Row>, Row, Column, DataType> getDocumenter()
+            throws ZinggClientException {
+        SparkDocumenter documenter = new SparkDocumenter(zinggSparkContext);
+        documenter.init(docArguments, sparkSession, new ClientOptions());
+        return documenter;
+    }
+}


### PR DESCRIPTION
## What

Adds an executor-level test for the `SparkDocumenter` phase (`generateDocs`). Until now the documenter component classes (`ModelDocumenter`, `DataDocumenter`, `DocumenterBase`) had unit tests, but the executor's `Documenter.execute()` path — which wires them together — had no coverage. Every other phase (Trainer, Matcher, Labeller, Linker) has an executor test; Documenter was the gap.

## How

- `TestDocumenterExecutorBase` — engine-agnostic base test. Loads the documenter test config, points `zinggDir` at the prepared model-100 fixture, points the input data at the test CSV, runs `execute()`, and asserts both `model.html` and `data.html` are generated.
- `TestSparkDocumenterExecutor` — Spark binding via `TestSparkBaseLite`.

Generated documents are deleted in a `finally` block so they never pollute the source tree.

## Testing

All documenter tests pass locally (JDK 11, Spark 3.5):

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

Closes #1304